### PR TITLE
fix: Changed From method to get the AVD name from the config.ini

### DIFF
--- a/UnoCheck/AndroidSdk/Avd.cs
+++ b/UnoCheck/AndroidSdk/Avd.cs
@@ -1,5 +1,4 @@
-﻿using IniParser;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -36,20 +35,26 @@ namespace DotNetCheck.AndroidSdk
 			{
 				try
 				{
-					var avdIniFile = System.IO.Path.Combine(avdPath, "..", System.IO.Path.GetFileNameWithoutExtension(avdPath) + ".ini");
 					var configIniFile = System.IO.Path.Combine(avdPath, "config.ini");
 
-					if (File.Exists(avdIniFile))
+					if (File.Exists(configIniFile))
 					{
-						var avdIni = ParseIni(avdIniFile);
-						
-						if (File.Exists(configIniFile))
-						{
-							var configIni = ParseIni(configIniFile);
+						var configIni = ParseIni(configIniFile);
+						if (!configIni.TryGetValue("AvdId", out var avdName))
+                        {
+							return null;
+                        }
 
-							var avd = new Avd();
-							avd.Name = System.IO.Path.GetFileNameWithoutExtension(avdIniFile);
-							avd.Path = avdPath;
+						var avd = new Avd();
+						avd.Name = avdName;
+						avd.Path = avdPath;
+
+						var avdIniFile = System.IO.Path.Combine(avdPath, "..", avdName) + ".ini";
+
+						if (File.Exists(avdIniFile))
+						{
+							var avdIni = ParseIni(avdIniFile);
+
 							if (avdIni.TryGetValue("target", out var avdTarget))
 								avd.Target = avdTarget;
 							if (configIni.TryGetValue("hw.device.name", out var avdDevice))
@@ -80,7 +85,7 @@ namespace DotNetCheck.AndroidSdk
 						var parts = line?.Split(new char[] { '=' }, 2);
 
 						if (parts?.Any() ?? false)
-							d[parts[0]] = parts[1];
+							d[parts[0].Trim()] = parts[1].Trim();
 					}
 				}
 


### PR DESCRIPTION
fix: Changed From method to get the AVD name from the config.ini

Reorganized the `From` method to extract the name of the AVD from the config.ini so that the *`<avd_name>.ini`* could be built.

Refs: #20