### PR TITLE
Get Avd configuration out of the folder name

### DIFF
--- a/UnoCheck/AndroidSdk/Avd.cs
+++ b/UnoCheck/AndroidSdk/Avd.cs
@@ -40,17 +40,21 @@ namespace DotNetCheck.AndroidSdk
 					if (File.Exists(configIniFile))
 					{
 						var configIni = ParseIni(configIniFile);
-						if (!configIni.TryGetValue("AvdId", out var avdName))
-                        {
-							return null;
-                        }
 
 						var avd = new Avd();
-						avd.Name = avdName;
 						avd.Path = avdPath;
+						string avdIniFile = "";
+						if (configIni.TryGetValue("AvdId", out var avdName))
+						{
+							avd.Name = avdName;
+							avdIniFile = System.IO.Path.Combine(avdPath, "..", avdName) + ".ini";
+						}
+						else
+						{
+							var configIniFolder = System.IO.Path.GetDirectoryName(configIniFile);
+							avdIniFile = System.IO.Path.GetFileNameWithoutExtension(configIniFolder) + ".ini";
 
-						var avdIniFile = System.IO.Path.Combine(avdPath, "..", avdName) + ".ini";
-
+						}
 						if (File.Exists(avdIniFile))
 						{
 							var avdIni = ParseIni(avdIniFile);


### PR DESCRIPTION
The **AvdId** property in doesn't seem to be around anymore in .android\avd\pixel5-_api_30.ini, that is used to set **Avd.Name** .
Keep doing it as before, and if that key doesn't exist, then replace _.avd_ by _.ini_ as per the folder structure: 
![image](https://user-images.githubusercontent.com/888391/149561133-231aae8f-e854-475f-a213-45e660205fb3.png)

