### PR TITLE
feat: add validation for long path support on windows

### DIFF
--- a/UnoCheck/Checkups/WindowsLongPathCheckup.cs
+++ b/UnoCheck/Checkups/WindowsLongPathCheckup.cs
@@ -1,0 +1,40 @@
+﻿#nullable enable
+
+using DotNetCheck.Models;
+using DotNetCheck.Solutions;
+using Microsoft.Win32;
+using System.Threading.Tasks;
+
+namespace DotNetCheck.Checkups
+{
+	public class WindowsLongPathCheckup : Checkup
+	{
+		public override string Id => "windowslongpath";
+
+		public override string Title => "Windows Long Path Checkup";
+
+		public override bool IsPlatformSupported(Platform platform) => platform == Platform.Windows;
+
+		public override async Task<DiagnosticResult> Examine(SharedState history)
+		{
+			RegistryKey fileSystemKey = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\FileSystem", true);
+
+			if (int.TryParse(fileSystemKey.GetValue(LongPathsEnabledKey)?.ToString(), out var value) && value is 0)
+			{
+				return await Task.FromResult(new DiagnosticResult(
+				Status.Error,
+				this,
+				new Suggestion("Enable long paths support on Windows",
+				new LongPathsNotEnabledSolution(fileSystemKey, LongPathsEnabledKey))));
+			}
+			else
+			{
+				ReportStatus($"Long paths are enabled on Windows!", Status.Ok);
+			}
+
+			return await Task.FromResult(DiagnosticResult.Ok(this));
+		}
+
+		private const string LongPathsEnabledKey = "LongPathsEnabled";
+	}
+}

--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -38,7 +38,8 @@ namespace DotNetCheck
 			CheckupManager.RegisterCheckups(
 				new DotNetSentinelCheckup(),
 				new WSLCheckup(),
-				new GTK3Checkup()
+				new GTK3Checkup(),
+				new WindowsLongPathCheckup()
 			);
 
 			var app = new CommandApp();

--- a/UnoCheck/Solutions/LongPathsNotEnabledSolution.cs
+++ b/UnoCheck/Solutions/LongPathsNotEnabledSolution.cs
@@ -1,0 +1,28 @@
+﻿using DotNetCheck.Models;
+using Microsoft.Win32;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotNetCheck.Solutions
+{
+	public class LongPathsNotEnabledSolution : Solution
+	{
+		public LongPathsNotEnabledSolution(RegistryKey fileSystemKey, string keyName) 
+		{
+			_fileSystemKey = fileSystemKey;
+			_keyName = keyName;
+		}
+
+		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
+		{
+			await base.Implement(sharedState, cancellationToken);
+
+			_fileSystemKey.SetValue(_keyName, 1);
+
+			ReportStatus("The long paths are enabled, you will need to reboot your machine for the change to take effect.");
+		}
+
+		private RegistryKey _fileSystemKey;
+		private string _keyName;
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #81 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

# PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
People from the community have reported that certain projects fail to build because of long paths.

This is a longstanding issue affecting Win32.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

The uno-check will apply the registry changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current Figma desktop app
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Unit Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes and the __PlugIn is BACKWARD COMPATIBLE__
- [x] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
