### PR TITLE
feat: Add validation for the presence of python

### DIFF
--- a/UnoCheck/Checkups/WindowsPhytonInstallationCheckup.cs
+++ b/UnoCheck/Checkups/WindowsPhytonInstallationCheckup.cs
@@ -18,18 +18,19 @@ namespace DotNetCheck.Checkups
 		public override async Task<DiagnosticResult> Examine(SharedState history)
 		{
 			RegistryKey pyLaucherKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\Python\PyLauncher", false);
+			string? path = pyLaucherKey.GetValue(InstallDirKey)?.ToString();
 
-			if (pyLaucherKey is null || string.IsNullOrEmpty(pyLaucherKey.GetValue(InstallDirKey)?.ToString()))
+			if (pyLaucherKey is null || string.IsNullOrEmpty(path))
 			{
 				return await Task.FromResult(new DiagnosticResult(
 				Status.Error,
 				this,
-				new Suggestion("To setup your machine to use AOT modes on Windows, you will need to install Python from Windows Store, or manually through Python's official site",
+				new Suggestion("In order to build WebAssembly apps using AOT, you will need to install Python from Windows Store, or manually through Python's official site",
 				new PytonIsInstalledSolution())));
 			}
 			else
 			{
-				ReportStatus($"Python is installed, you can use WebAssembly AOT modules on Windows!", Status.Ok);
+				ReportStatus($"Python is installed in {path}.", Status.Ok);
 			}
 
 			return await Task.FromResult(DiagnosticResult.Ok(this));

--- a/UnoCheck/Checkups/WindowsPhytonInstallationCheckup.cs
+++ b/UnoCheck/Checkups/WindowsPhytonInstallationCheckup.cs
@@ -1,0 +1,40 @@
+﻿#nullable enable
+
+using DotNetCheck.Models;
+using DotNetCheck.Solutions;
+using Microsoft.Win32;
+using System.Threading.Tasks;
+
+namespace DotNetCheck.Checkups
+{
+	public class WindowsPhytonInstallationCheckup : Checkup
+	{
+		public override string Id => "windowsphytonInstallation";
+
+		public override string Title => "Windows Phyton Installation Checkup";
+
+		public override bool IsPlatformSupported(Platform platform) => platform == Platform.Windows;
+
+		public override async Task<DiagnosticResult> Examine(SharedState history)
+		{
+			RegistryKey pyLaucherKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\Python\PyLauncher", false);
+
+			if (pyLaucherKey is null || string.IsNullOrEmpty(pyLaucherKey.GetValue(InstallDirKey)?.ToString()))
+			{
+				return await Task.FromResult(new DiagnosticResult(
+				Status.Error,
+				this,
+				new Suggestion("To setup your machine to use AOT modes on Windows, you will need to install Python from Windows Store, or manually through Python's official site",
+				new PytonIsInstalledSolution())));
+			}
+			else
+			{
+				ReportStatus($"Python is installed, you can use WebAssembly AOT modules on Windows!", Status.Ok);
+			}
+
+			return await Task.FromResult(DiagnosticResult.Ok(this));
+		}
+
+		private const string InstallDirKey = "InstallDir";
+	}
+}

--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -39,7 +39,8 @@ namespace DotNetCheck
 				new DotNetSentinelCheckup(),
 				new WSLCheckup(),
 				new GTK3Checkup(),
-				new WindowsLongPathCheckup()
+				new WindowsLongPathCheckup(),
+				new WindowsPhytonInstallationCheckup()
 			);
 
 			var app = new CommandApp();

--- a/UnoCheck/Solutions/PytonIsInstalledSolution.cs
+++ b/UnoCheck/Solutions/PytonIsInstalledSolution.cs
@@ -23,9 +23,9 @@ namespace DotNetCheck.Solutions
 			};
 			_ = Process.Start(ps);
 
-			ReportStatus("The Phyton version can be downloaded on this website..");
+			ReportStatus("The Phyton version can be downloaded from Windows Store.");
 		}
 		
-		private const string PythonDownloadUrl = "https://www.python.org/downloads/";
+		private const string PythonDownloadUrl = "https://www.microsoft.com/store/productId/9PJPW5LDXLZ5";
 	}
 }

--- a/UnoCheck/Solutions/PytonIsInstalledSolution.cs
+++ b/UnoCheck/Solutions/PytonIsInstalledSolution.cs
@@ -1,0 +1,31 @@
+﻿using DotNetCheck.Models;
+using Microsoft.Win32;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotNetCheck.Solutions
+{
+	public class PytonIsInstalledSolution : Solution
+	{
+		public PytonIsInstalledSolution()
+		{
+		}
+
+		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
+		{
+			await base.Implement(sharedState, cancellationToken);
+
+			var ps = new ProcessStartInfo(PythonDownloadUrl)
+			{
+				UseShellExecute = true,
+				Verb = "open"
+			};
+			_ = Process.Start(ps);
+
+			ReportStatus("The Phyton version can be downloaded on this website..");
+		}
+		
+		private const string PythonDownloadUrl = "https://www.python.org/downloads/";
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #82 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

# PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
People from the community have reported that certain projects fail to build because of long paths.

There is no check to Python presence on Windows.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

The uno-check will validate the presence of python.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current Figma desktop app
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Unit Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes and the __PlugIn is BACKWARD COMPATIBLE__
- [x] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
