### PR TITLE
feat: Add validation for Hyper-V on Windows

### DIFF
--- a/UnoCheck/Checkups/HyperVCheckup.cs
+++ b/UnoCheck/Checkups/HyperVCheckup.cs
@@ -24,7 +24,7 @@ namespace DotNetCheck.Checkups
 				return Task.FromResult(new DiagnosticResult(
 				Status.Warning,
 				this,
-				new Suggestion($"Activate Hyper-V on this computer to benefit from faster Android Emulators!",
+				new Suggestion($"Activate Hyper-V on this computer to benefit from faster Android Emulators",
 				new HyperVActivationSolution())));
 			}
 			else

--- a/UnoCheck/Checkups/HyperVCheckup.cs
+++ b/UnoCheck/Checkups/HyperVCheckup.cs
@@ -29,7 +29,7 @@ namespace DotNetCheck.Checkups
 			}
 			else
 			{
-				ReportStatus($"Hyper-V is configured!", Status.Ok);
+				ReportStatus($"Hyper-V is configured", Status.Ok);
 
 				return Task.FromResult(DiagnosticResult.Ok(this));
 			}

--- a/UnoCheck/Checkups/HyperVCheckup.cs
+++ b/UnoCheck/Checkups/HyperVCheckup.cs
@@ -1,0 +1,68 @@
+﻿#nullable enable
+
+using DotNetCheck.Models;
+using DotNetCheck.Solutions;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace DotNetCheck.Checkups
+{
+	public class HyperVCheckup : Checkup
+	{
+		public override string Id => "windowshyperv";
+
+		public override string Title => $"Windows Hyper-V Checkup";
+
+		public override bool IsPlatformSupported(Platform platform) => platform == Platform.Windows;
+
+		public override Task<DiagnosticResult> Examine(SharedState history)
+		{
+			if (!this.GetHyperVStatus())
+			{
+				return Task.FromResult(new DiagnosticResult(
+				Status.Warning,
+				this,
+				new Suggestion($"Activate Hyper-V on this computer to benefit from faster Android Emulators!",
+				new HyperVActivationSolution())));
+			}
+			else
+			{
+				ReportStatus($"Hyper-V is configured!", Status.Ok);
+
+				return Task.FromResult(DiagnosticResult.Ok(this));
+			}
+		}
+
+		private bool GetHyperVStatus()
+		{
+			var startInfo = new ProcessStartInfo
+			{
+				Arguments = "/enum {current}",
+				CreateNoWindow = true,
+				FileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "bcdedit.exe"),
+				RedirectStandardOutput = true,
+				UseShellExecute = false
+			};
+			using (var process = Process.Start(startInfo))
+			{
+				process.WaitForExit();
+
+				while (!process.StandardOutput.EndOfStream)
+				{
+					string? line = process.StandardOutput.ReadLine();
+
+					if (!string.IsNullOrEmpty(line))
+					{
+						if (line.StartsWith("hypervisorlaunchtype ", StringComparison.OrdinalIgnoreCase))
+						{
+							return line.IndexOf(" off", StringComparison.OrdinalIgnoreCase) == -1;
+						}
+					}
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -41,7 +41,8 @@ namespace DotNetCheck
 				new GTK3Checkup(),
 				new WindowsPhytonInstallationCheckup(),
 				new WindowsLongPathCheckup(),
-				new LinuxNinjaPresenceCheckup()
+				new LinuxNinjaPresenceCheckup(),
+				new HyperVCheckup()
 			);
 
 			var app = new CommandApp();

--- a/UnoCheck/Solutions/HyperVActivationSolution.cs
+++ b/UnoCheck/Solutions/HyperVActivationSolution.cs
@@ -1,0 +1,54 @@
+﻿using DotNetCheck.Models;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotNetCheck.Solutions
+{
+	public class HyperVActivationSolution : Solution
+	{
+		public HyperVActivationSolution()
+		{
+		}
+
+		public override Task Implement(SharedState sharedState, CancellationToken cancellationToken)
+		{
+			if (this.ActivateHyperV())
+			{
+				ReportStatus("Hyper-V activated. Please, restart your computer.");
+			}
+			else
+			{
+				throw new InvalidOperationException("Please, restart your computer to complete the Hyper-V activation process.");
+			}
+
+			return Task.CompletedTask;
+		}
+
+		private bool ActivateHyperV()
+		{
+			string dsimPath = Path.Combine(Environment.ExpandEnvironmentVariables("%windir%"), "system32", "dism.exe");
+
+			if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+			{
+				// For 32-bit processes on 64-bit systems, %windir%\system32 folder
+				// can only be accessed by specifying %windir%\sysnative folder.
+				dsimPath = Path.Combine(Environment.ExpandEnvironmentVariables("%windir%"), "sysnative", "dism.exe");
+			}
+
+			var dism = ShellProcessRunner.Run(dsimPath, "/Online /Enable-Feature /Quiet /NoRestart /All /FeatureName:Microsoft-Hyper-V");
+
+			if(dism.ExitCode == RebootRequired)
+			{
+				ReportStatus("Please, restart your computer to complete the Hyper-V activation process.");
+
+				return false;
+			}
+
+			return dism.ExitCode == 0;
+		}
+
+		private const int RebootRequired = 3010;
+	}
+}

--- a/UnoCheck/UnoCheck.csproj
+++ b/UnoCheck/UnoCheck.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
 		<PackageReference Include="NuGet.Packaging" Version="5.10.0" />
 		<PackageReference Include="NuGet.Protocol" Version="5.10.0" />
 		<PackageReference Include="NuGet.Versioning" Version="5.10.0" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #46 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

# PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
People from the community have reported that certain projects fail to build because of long paths.

There is no check to Hyper-V activation on Windows.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

The uno-check will validate the presence of Hyper-V and install if required.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current Figma desktop app
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Unit Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes and the __PlugIn is BACKWARD COMPATIBLE__
- [x] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
