### PR TITLE
fix: installation of OpenJDK for macos-arm64

### DIFF
--- a/UnoCheck/Checkups/OpenJdkCheckup.cs
+++ b/UnoCheck/Checkups/OpenJdkCheckup.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xamarin.Android.Tools;
@@ -97,9 +97,13 @@ namespace DotNetCheck.Checkups
 			if (ok)
 				return Task.FromResult(DiagnosticResult.Ok(this));
 
+			var url = Manifest?.Check?.OpenJdk?.Url;
+			if (url is not null && RuntimeInformation.OSArchitecture == Architecture.Arm64) {
+				url = new (url.ToString().Replace("-x64.", "-aarch64."));
+			}
 			return Task.FromResult(new DiagnosticResult(Status.Error, this,
 				new Suggestion("Install OpenJDK11",
-					new BootsSolution(Manifest?.Check?.OpenJdk?.Url, "Download and Install Microsoft OpenJDK 11"))));
+					new BootsSolution(url, "Download and Install Microsoft OpenJDK 11"))));
 		}
 
 		IEnumerable<OpenJdkInfo> FindJdks()

--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -2,7 +2,7 @@
   "check": {
     "toolVersion": "1.5.0",
     "variables": {
-      "OPENJDK_VERSION": "11.0.10.9",
+      "OPENJDK_VERSION": "11.0.16",
       "DOTNET_SDK_VERSION": "7.0.100",
       "MACCATALYST_SDK_VERSION": "15.4.2372/7.0.100",
       "IOS_SDK_VERSION": "16.0.1478/7.0.100",

--- a/manifests/uno.ui.manifest.json
+++ b/manifests/uno.ui.manifest.json
@@ -2,7 +2,7 @@
   "check": {
     "toolVersion": "1.5.0",
     "variables": {
-      "OPENJDK_VERSION": "11.0.10.9",
+      "OPENJDK_VERSION": "11.0.16",
       "DOTNET_SDK_VERSION": "7.0.100",
       "MACCATALYST_SDK_VERSION": "15.4.2372/7.0.100",
       "IOS_SDK_VERSION": "16.0.1478/7.0.100",


### PR DESCRIPTION
The wrong arch (x64) was downloaded.

The same fix should also work for Windows and eventually Linux (not part of the manifest) based on the packages names from https://learn.microsoft.com/en-us/java/openjdk/older-releases#openjdk-11

Also bump the version so binaries for arm64 are available to download.