### PR TITLE
feat(vswindows): Add WASDK workloads to match docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           & dotnet --list-sdks
           & dotnet tool install --global --version ${{ matrix.previous_tool_version }} uno.check
-          & uno-check --ci --fix --non-interactive --verbose --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2  ${{ matrix.previous_tool_params }}
+          & uno-check --ci --fix --non-interactive --verbose --target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2  ${{ matrix.previous_tool_params }}
           & dotnet tool uninstall --global uno.check
 
       - name: Install and Run Tool
@@ -136,7 +136,7 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           & dotnet --list-sdks
           & dotnet tool install --global --version ${{ steps.gitversion.outputs.semVer }} --add-source NuGet\ uno.check
-          & uno-check --ci --fix --non-interactive --verbose --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 --manifest ${{ matrix.manifest }}
+          & uno-check --ci --fix --non-interactive --verbose --target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 --manifest ${{ matrix.manifest }}
 
   testmac:
     name: Validate Tool - macOS - ${{ matrix.manifest_name }}/${{ matrix.os }}

--- a/UnoCheck/CheckSettings.Uno.cs
+++ b/UnoCheck/CheckSettings.Uno.cs
@@ -13,7 +13,7 @@ namespace DotNetCheck
 		[CommandOption("--target <TARGET_PLATFORM_ID>")]
 		[Description(
 @"Run checks for a specific target platform. Use the --target option multiple times to run checks for multiple platforms, or omit it to run checks for all supported platforms.
-Targets: webassembly ios android macos linux uwp win32desktop"
+Targets: webassembly ios android macos linux wasdk uwp"
 			)]
 		public string[]? TargetPlatforms { get; set; }
 	}

--- a/UnoCheck/CheckSettings.Uno.cs
+++ b/UnoCheck/CheckSettings.Uno.cs
@@ -13,7 +13,7 @@ namespace DotNetCheck
 		[CommandOption("--target <TARGET_PLATFORM_ID>")]
 		[Description(
 @"Run checks for a specific target platform. Use the --target option multiple times to run checks for multiple platforms, or omit it to run checks for all supported platforms.
-Targets: webassembly ios android macos linux wasdk uwp"
+Targets: webassembly ios android macos linux windows"
 			)]
 		public string[]? TargetPlatforms { get; set; }
 	}

--- a/UnoCheck/TargetPlatform.cs
+++ b/UnoCheck/TargetPlatform.cs
@@ -15,7 +15,7 @@ namespace DotNetCheck
 		SkiaWPF = 16,
 		SkiaGtk = 32,
 		SkiaTizen = 64,
-		UWP = 128,
+		Windows = 128,
 		WinAppSDK = 256,
 
 		All = -1

--- a/UnoCheck/TargetPlatform.cs
+++ b/UnoCheck/TargetPlatform.cs
@@ -16,7 +16,7 @@ namespace DotNetCheck
 		SkiaGtk = 32,
 		SkiaTizen = 64,
 		UWP = 128,
-		Win32Desktop = 256,
+		WinAppSDK = 256,
 
 		All = -1
 	}

--- a/UnoCheck/TargetPlatformHelper.cs
+++ b/UnoCheck/TargetPlatformHelper.cs
@@ -50,9 +50,10 @@ namespace DotNetCheck
 					return TargetPlatform.SkiaTizen;
 				case "uwp":
 					return TargetPlatform.UWP;
+				case "wasdk":
 				case "win32desktop":
 				case "win32":
-					return TargetPlatform.Win32Desktop;
+					return TargetPlatform.WinAppSDK;
 
 				case "skia":
 					return TargetPlatform.SkiaWPF | TargetPlatform.SkiaGtk | TargetPlatform.SkiaTizen;

--- a/UnoCheck/TargetPlatformHelper.cs
+++ b/UnoCheck/TargetPlatformHelper.cs
@@ -48,13 +48,12 @@ namespace DotNetCheck
 				case "skiatizen":
 				case "skia-tizen":
 					return TargetPlatform.SkiaTizen;
-				case "uwp":
-					return TargetPlatform.UWP;
-				case "wasdk":
-				case "win32desktop":
-				case "win32":
+                case "windows":
+                case "wasdk":
 					return TargetPlatform.WinAppSDK;
-
+                case "win32desktop":
+                case "win32":
+                    return TargetPlatform.Windows;
 				case "skia":
 					return TargetPlatform.SkiaWPF | TargetPlatform.SkiaGtk | TargetPlatform.SkiaTizen;
 				case "linux":

--- a/manifests/uno.ui-preview-major.manifest.json
+++ b/manifests/uno.ui-preview-major.manifest.json
@@ -136,7 +136,8 @@
           "id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
           "name": ".NET desktop development",
           "requiredby": [
-            "wasdk"
+            "wasdk",
+            "win32"
           ]
         },
         {

--- a/manifests/uno.ui-preview-major.manifest.json
+++ b/manifests/uno.ui-preview-major.manifest.json
@@ -133,10 +133,17 @@
     "vswindows": {
       "workloads": [
         {
-          "id": "Microsoft.VisualStudio.Workload.Universal",
-          "name": "Universal Windows Platform development",
+          "id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
+          "name": ".NET desktop development",
           "requiredby": [
-            "uwp"
+            "wasdk"
+          ]
+        },
+        {
+          "id": "Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs",
+          "name": "Windows App SDK C# Templates",
+          "requiredby": [
+            "wasdk"
           ]
         },
         {

--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -136,7 +136,8 @@
           "id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
           "name": ".NET desktop development",
           "requiredby": [
-            "wasdk"
+            "wasdk",
+            "win32"
           ]
         },
         {

--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -133,10 +133,17 @@
     "vswindows": {
       "workloads": [
         {
-          "id": "Microsoft.VisualStudio.Workload.Universal",
-          "name": "Universal Windows Platform development",
+          "id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
+          "name": ".NET desktop development",
           "requiredby": [
-            "uwp"
+            "wasdk"
+          ]
+        },
+        {
+          "id": "Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs",
+          "name": "Windows App SDK C# Templates",
+          "requiredby": [
+            "wasdk"
           ]
         },
         {

--- a/manifests/uno.ui.manifest.json
+++ b/manifests/uno.ui.manifest.json
@@ -136,7 +136,8 @@
           "id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
           "name": ".NET desktop development",
           "requiredby": [
-            "wasdk"
+            "wasdk",
+            "win32"
           ]
         },
         {

--- a/manifests/uno.ui.manifest.json
+++ b/manifests/uno.ui.manifest.json
@@ -133,10 +133,17 @@
     "vswindows": {
       "workloads": [
         {
-          "id": "Microsoft.VisualStudio.Workload.Universal",
-          "name": "Universal Windows Platform development",
+          "id": "Microsoft.VisualStudio.Workload.ManagedDesktop",
+          "name": ".NET desktop development",
           "requiredby": [
-            "uwp"
+            "wasdk"
+          ]
+        },
+        {
+          "id": "Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs",
+          "name": "Windows App SDK C# Templates",
+          "requiredby": [
+            "wasdk"
           ]
         },
         {


### PR DESCRIPTION
Universal Windows Platform development tools represent a fairly significant dependency, which may be an obstacle to quickly getting started with Uno development.

Fortunately, the dependencies on our getting started documentation were recently updated to match the Microsoft-endorsed workloads for Windows App SDK.  Accordingly, we advise new users to run the `uno-check` tool to pull down the required workloads if they're missing. 

This PR updates our tool to no longer assume UWP workload is needed: matching the docs. It does this by using the workload ids which Microsoft details in its getting started with WASDK docs. This change is _not_ breaking because it maintains compatibility with the previous target platform strings: "win32" and "win32desktop".