### PR TITLE
fix: Don't fail on more recent .NET installed version for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
            previous_tool_version: 1.4.2
            previous_tool_params: ''
            os: macos-11
-           dotnet_version: 7.0.102
+           dotnet_version: 7.0.401
 
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview Upgrade
@@ -188,7 +188,7 @@ jobs:
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Stable
            os: macos-12
-           dotnet_version: 7.0.102
+           dotnet_version: 7.0.401
 
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview
@@ -209,7 +209,7 @@ jobs:
            previous_tool_version: 1.4.2
            previous_tool_params: ''
            os: macos-12
-           dotnet_version: 7.0.102
+           dotnet_version: 7.0.401
 
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview Upgrade

--- a/UnoCheck/Manifest/Manifest.cs
+++ b/UnoCheck/Manifest/Manifest.cs
@@ -8,9 +8,9 @@ namespace DotNetCheck.Manifest
 {
 	public partial class Manifest
 	{
-		public const string DefaultManifestUrl = "https://raw.githubusercontent.com/unoplatform/uno.check/9b20cf688c11f456c6cabbf788ce98fbd666995e/manifests/uno.ui.manifest.json";
-        public const string PreviewManifestUrl = "https://raw.githubusercontent.com/unoplatform/uno.check/9b20cf688c11f456c6cabbf788ce98fbd666995e/manifests/uno.ui-preview.manifest.json";
-        public const string PreviewMajorManifestUrl = "https://raw.githubusercontent.com/unoplatform/uno.check/9b20cf688c11f456c6cabbf788ce98fbd666995e/manifests/uno.ui-preview-major.manifest.json";
+		public const string DefaultManifestUrl = "https://raw.githubusercontent.com/unoplatform/uno.check/f20a61715347d754d957c986438d2e96fc14ac5a/manifests/uno.ui.manifest.json";
+        public const string PreviewManifestUrl = "https://raw.githubusercontent.com/unoplatform/uno.check/f20a61715347d754d957c986438d2e96fc14ac5a/manifests/uno.ui-preview.manifest.json";
+        public const string PreviewMajorManifestUrl = "https://raw.githubusercontent.com/unoplatform/uno.check/f20a61715347d754d957c986438d2e96fc14ac5a/manifests/uno.ui-preview-major.manifest.json";
 
         public static Task<Manifest> FromFileOrUrl(string fileOrUrl)
 		{

--- a/UnoCheck/Solutions/MsInstallerSolution.cs
+++ b/UnoCheck/Solutions/MsInstallerSolution.cs
@@ -102,13 +102,8 @@ namespace DotNetCheck.Solutions
 					// Newer version already installed
 					if (logText.Contains("0x80070666"))
 					{
-						var existsMsg = $"Installation failed for {Title ?? Url.ToString()}."
-							+ Environment.NewLine + "A newer version of dotnet SDK is already installed"
-							+ Environment.NewLine + $"See log file for more details: {logFile}";
-
-						ReportStatus(existsMsg);
-
-						throw new Exception(existsMsg);
+						ReportStatus($"Installation skipped as a more recent version is installed {Title ?? Url.ToString()}. (See log file for more details: {logFile})");
+						return;
 					}
 				}
 

--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -3,7 +3,7 @@
     "toolVersion": "1.5.0",
     "variables": {
       "OPENJDK_VERSION": "11.0.16",
-      "DOTNET_SDK_VERSION": "7.0.400",
+      "DOTNET_SDK_VERSION": "7.0.401",
       "MACCATALYST_SDK_VERSION": "16.4.7054/7.0.100",
       "IOS_SDK_VERSION": "16.4.7054/7.0.100",
       "MACOS_SDK_VERSION": "13.3.7054/7.0.100",

--- a/manifests/uno.ui.manifest.json
+++ b/manifests/uno.ui.manifest.json
@@ -3,7 +3,7 @@
     "toolVersion": "1.5.0",
     "variables": {
       "OPENJDK_VERSION": "11.0.16",
-      "DOTNET_SDK_VERSION": "7.0.400",
+      "DOTNET_SDK_VERSION": "7.0.401",
       "MACCATALYST_SDK_VERSION": "16.4.7054/7.0.100",
       "IOS_SDK_VERSION": "16.4.7054/7.0.100",
       "MACOS_SDK_VERSION": "13.3.7054/7.0.100",


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.check/issues/168