### PR TITLE
fix: Fix Xcode version checks and manifests

### DIFF
--- a/manifests/uno.ui-preview-major.manifest.json
+++ b/manifests/uno.ui-preview-major.manifest.json
@@ -20,8 +20,8 @@
       }
     },
     "xcode": {
-      "exactVersion": "14E300c",
-      "exactVersionName": "14.3.1"
+      "exactVersion": "15.0",
+      "exactVersionName": "15A240d"
     },
     "vswin": {
       "minimumVersion": "17.8.0-pre.1"

--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -20,8 +20,8 @@
       }
     },
     "xcode": {
-      "exactVersion": "14E300c",
-      "exactVersionName": "14.3.1"
+      "exactVersion": "14.3.1",
+      "exactVersionName": "14E300c"
     },
     "vswin": {
       "minimumVersion": "17.4.4"

--- a/manifests/uno.ui.manifest.json
+++ b/manifests/uno.ui.manifest.json
@@ -20,8 +20,8 @@
       }
     },
     "xcode": {
-      "exactVersion": "14E300c",
-      "exactVersionName": "14.3.1"
+      "exactVersion": "14.3.1",
+      "exactVersionName": "14E300c"
     },
     "vswin": {
       "minimumVersion": "17.4.4"


### PR DESCRIPTION
* Fix the manifest (inverted version/name)
* Update preview manifest with Xcode 15
* Parse the correct string to retrive the Xcode version from `Info.plist`
* On success show the installed Xcode version (and not the one specified in the manifest). That can be confusing if `minimum` is used in the manifest files
