### PR TITLE
fix(androidsdk): only download arch independent or matching the host archives

### DIFF
--- a/UnoCheck/Checkups/AndroidSdkCheckup.cs
+++ b/UnoCheck/Checkups/AndroidSdkCheckup.cs
@@ -202,7 +202,7 @@ For more information see: [underline]https://aka.ms/dotnet-androidsdk-help[/]";
 							{
 									// Provide a default timeout value of 7 minutes if a value is not provided.
 								httpClient.Timeout = TimeSpan.FromMinutes(120);
-								await Task.WhenAll(downloads.Select(d => Download(httpClient, d)));
+								await Task.WhenAll(downloads.Where(d => (d.HostArch == null) || (d.HostArch == (Util.IsArm64 ? "aarch64" : "x64"))).Select(d => Download(httpClient, d)));
 							}
 
 							installer.Install(sdkInstance, installationSet);


### PR DESCRIPTION
This avoid downloading multiple files (one per arch) where the last one will be decompressed over the previous. E.g. ending up having `emulator` as a `arm64` binary on an `x86` Mac.

Previous verbose logs showed:
```
...
  – Downloading https://dl.google.com/android/repository/emulator-darwin_x64-10696886.zip ...
  – Downloading https://dl.google.com/android/repository/emulator-darwin_aarch64-10696886.zip
...
```