### PR TITLE
fix: Ensure dotnet template uses en culture for parsing the output

### DIFF
--- a/UnoCheck/Checkups/DotNetNewUnoTemplatesCheckup.cs
+++ b/UnoCheck/Checkups/DotNetNewUnoTemplatesCheckup.cs
@@ -70,6 +70,7 @@ internal class DotNetNewUnoTemplatesCheckup : Checkup
         var processInfo = new ProcessStartInfo("dotnet", "new uninstall");
         processInfo.RedirectStandardOutput = true;
         processInfo.UseShellExecute = false;
+        processInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
 
         var process = Process.Start(processInfo);
         string output = process.StandardOutput.ReadToEnd();


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno.check/issues/212