### PR TITLE
chore: Update checkups files to remove duplicate checkup word

### DIFF
--- a/UnoCheck/Checkups/HyperVCheckup.cs
+++ b/UnoCheck/Checkups/HyperVCheckup.cs
@@ -13,7 +13,7 @@ namespace DotNetCheck.Checkups
 	{
 		public override string Id => "windowshyperv";
 
-		public override string Title => $"Windows Hyper-V Checkup";
+		public override string Title => $"Windows Hyper-V";
 
 		public override bool IsPlatformSupported(Platform platform) => platform == Platform.Windows;
 

--- a/UnoCheck/Checkups/WindowsLongPathCheckup.cs
+++ b/UnoCheck/Checkups/WindowsLongPathCheckup.cs
@@ -11,7 +11,7 @@ namespace DotNetCheck.Checkups
 	{
 		public override string Id => "windowslongpath";
 
-		public override string Title => "Windows Long Path Checkup";
+		public override string Title => "Windows Long Path";
 
 		public override bool IsPlatformSupported(Platform platform) => platform == Platform.Windows;
 

--- a/UnoCheck/Checkups/WindowsPythonInstallationCheckup.cs
+++ b/UnoCheck/Checkups/WindowsPythonInstallationCheckup.cs
@@ -13,7 +13,7 @@ namespace DotNetCheck.Checkups
     {
         public override string Id => "windowspyhtonInstallation";
 
-        public override string Title => "Windows Python Installation Checkup";
+        public override string Title => "Windows Python Installation";
 
         public override bool IsPlatformSupported(Platform platform) => platform == Platform.Windows;
 


### PR DESCRIPTION
## What is the current behavior?

Duplicated **Checkup** words for some checkups for uno-check
![image](https://github.com/unoplatform/uno.check/assets/16295702/4e9c1ada-36de-4b0a-8fa1-07c6d9fffa01)

## What is the new behavior?

No more duplicated **Checkup** words