### PR TITLE
fix: Do not hardcode path in launchsettings.json

### DIFF
--- a/UnoCheck/Properties/launchSettings.json
+++ b/UnoCheck/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "UnoCheck": {
       "commandName": "Project",
-      "commandLineArgs": "--verbose --manifest D:\\source\\unoplatform\\uno.check\\manifests\\uno.ui.manifest.json"
+      "commandLineArgs": "--verbose --manifest ..\\..\\..\\..\\manifests\\uno.ui.manifest.json"
     },
     "WSL 2": {
       "commandName": "WSL2",


### PR DESCRIPTION
Previously the path was hardcoded which would give you an error when trying to run the program 