### PR TITLE
fix: Incorrect output from DotNetNewUnoTemplatesCheckup

### DIFF
--- a/UnoCheck/Checkups/DotNetNewUnoTemplatesCheckup.cs
+++ b/UnoCheck/Checkups/DotNetNewUnoTemplatesCheckup.cs
@@ -56,7 +56,7 @@ internal class DotNetNewUnoTemplatesCheckup : Checkup
                 this,
                 new Suggestion(
                     $"The {TemplatesDisplayName} dotnet new command line templates are not up to date " +
-                    $"(installed version {version}, latest available version {latestVersion}.",
+                    $"(installed version {version}, latest available version {latestVersion}).",
                     new DotNetNewTemplatesInstallSolution(legacyVersion is not null, true, latestVersion)));
         }
 
@@ -84,7 +84,7 @@ internal class DotNetNewUnoTemplatesCheckup : Checkup
         if (match.Success)
         {
             var version = match.Groups.Values.Last();
-            if (NuGetVersion.TryParse(version.Value, out var parsedVersion))
+            if (NuGetVersion.TryParse(version.Value.Trim(), out var parsedVersion))
             {
                 return parsedVersion;
             }


### PR DESCRIPTION
The problem was that when we were parsing the version of uno.templates the result in some cases was like -"5.3.96/r" where /r would reset the caret to the start of the line. So the result was messed up. Now we are trimming all the whitespace characters from the version string. Also fixed the typo
Fixes #236 
Fixes #277