### PR TITLE
fix: do not display output when running xcodebuild

### DIFF
--- a/UnoCheck/Checkups/XCodeCheckup.cs
+++ b/UnoCheck/Checkups/XCodeCheckup.cs
@@ -52,10 +52,7 @@ namespace DotNetCheck.Checkups
 				if (selected is not null && selected.Version.IsCompatible(MinimumVersion, ExactVersion))
 				{
 					// customize runner options so the license can be displayed
-					var options = new ShellProcessRunnerOptions("xcodebuild", "")
-					{
-						RedirectOutput = Util.CI
-					};
+					var options = new ShellProcessRunnerOptions("xcodebuild", "");
 					var runner = new ShellProcessRunner(options);
 					var result = runner.WaitForExit();
 					// Check if user requires EULA to be accepted


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno.check/issues/279

`xcodebuild` will fail [1] and the error can be confusing to people running `uno-check`.

[1] it fails because there's no Xcode project to run, which is normal, but it fails **differently** when the EULA was not accepted - which is what we're looking for,
