### PR TITLE
feat: Add TFM based checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
            manifest_name: Stable
            os: macos-12
            dotnet_version: 8.0.300
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
 
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview
@@ -189,6 +190,7 @@ jobs:
            previous_tool_params: ''
            os: macos-12
            dotnet_version: 8.0.300
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
 
         #  - manifest: 'manifests/uno.ui-preview-major.manifest.json'
         #    manifest_name: Preview net9
@@ -203,6 +205,7 @@ jobs:
            previous_tool_params: ''
            os: macos-12
            dotnet_version: 8.0.300
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
 
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview Upgrade
@@ -210,7 +213,22 @@ jobs:
            previous_tool_params: '--pre'
            os: macos-12
            dotnet_version: 8.0.300
-
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+         - manifest: 'manifests/uno.ui.manifest.json'
+           manifest_name: Test default Uno template TFM's
+           os: macos-12
+           dotnet_version: 8.0.300
+           tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
+         - manifest: 'manifests/uno.ui.manifest.json'
+           manifest_name: Test net9.0 TFM
+           os: macos-12
+           dotnet_version: 8.0.300
+           tool_params: '--tfm net9.0'
+         - manifest: 'manifests/uno.ui.manifest.json'
+           manifest_name: Test outdated TFM's
+           os: macos-12
+           dotnet_version: 8.0.300
+           tool_params: '--tfm netcoreapp3.1 --tfm net452'
         #  - manifest: 'manifests/uno.ui-preview-major.manifest.json'
         #    manifest_name: Preview Upgrade net8
         #    previous_tool_version: 1.4.2
@@ -284,7 +302,7 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           & dotnet --list-sdks
           & dotnet tool install --global --version ${{ steps.gitversion.outputs.semVer }} --add-source NuGet/ uno.check
-          & uno-check --ci --fix --non-interactive --verbose --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 --manifest ${{ matrix.manifest }}
+          & uno-check --ci --fix --non-interactive --verbose --manifest ${{ matrix.manifest }} ${{ matrix.tool_params }}
 
   testlinux:
     name: Validate Tool - Linux - ${{ matrix.manifest_name }}
@@ -296,23 +314,37 @@ jobs:
        include:
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Stable
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui-preview-major.manifest.json'
            manifest_name: Preview net9
-
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Stable Upgrade
            previous_tool_version: 1.4.2
            previous_tool_params: ''
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview Upgrade
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui-preview-major.manifest.json'
            manifest_name: Preview Upgrade net8
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
+           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test default Uno template TFM's
+           tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net9.0 TFM
+           tool_params: '--tfm net9.0'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test outdated TFM's
+           tool_params: '--tfm netcoreapp3.1 --tfm net452'
 
     steps:
       - name: Checkout
@@ -365,7 +397,7 @@ jobs:
           Write-Output "PACKAGE VERSION: ${{ steps.gitversion.outputs.semVer }}"
           $ProgressPreference = 'SilentlyContinue'
           & dotnet tool install --global --version ${{ steps.gitversion.outputs.semVer }} --add-source NuGet/ uno.check
-          & uno-check --ci --fix --verbose --non-interactive --verbose --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 --manifest ${{ matrix.manifest }}
+          & uno-check --ci --fix --verbose --non-interactive --verbose --manifest ${{ matrix.manifest }} ${{ matrix.tool_params }}
 
   sign:
     name: Sign Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,12 +114,6 @@ jobs:
          - manifest: 'manifests\uno.ui.manifest.json'
            manifest_name: Test default Uno template TFM's
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
-         - manifest: 'manifests\uno.ui.manifest.json'
-           manifest_name: Test net9.0 TFM
-           tool_params: '--tfm net9.0'
-         - manifest: 'manifests\uno.ui.manifest.json'
-           manifest_name: Test outdated TFM's
-           tool_params: '--tfm netcoreapp3.1 --tfm net452'
 
     steps:
       - name: Checkout
@@ -215,16 +209,6 @@ jobs:
            os: macos-12
            dotnet_version: 8.0.300
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
-         - manifest: 'manifests/uno.ui.manifest.json'
-           manifest_name: Test net9.0 TFM
-           os: macos-12
-           dotnet_version: 8.0.300
-           tool_params: '--tfm net9.0'
-         - manifest: 'manifests/uno.ui.manifest.json'
-           manifest_name: Test outdated TFM's
-           os: macos-12
-           dotnet_version: 8.0.300
-           tool_params: '--tfm netcoreapp3.1 --tfm net452'
         #  - manifest: 'manifests/uno.ui-preview-major.manifest.json'
         #    manifest_name: Preview Upgrade net8
         #    previous_tool_version: 1.4.2
@@ -335,12 +319,6 @@ jobs:
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test default Uno template TFM's
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
-         - manifest: 'manifests/uno.ui.manifest.json'
-           manifest_name: Test net9.0 TFM
-           tool_params: '--tfm net9.0'
-         - manifest: 'manifests/uno.ui.manifest.json'
-           manifest_name: Test outdated TFM's
-           tool_params: '--tfm netcoreapp3.1 --tfm net452'
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,12 +215,12 @@ jobs:
            os: macos-12
            dotnet_version: 8.0.300
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
-         - manifest: 'manifests\uno.ui.manifest.json'
+         - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net8.0-android\ios TFM's
            os: macos-12
            dotnet_version: 8.0.300
            tool_params: '--tfm net8.0-android --tfm net8.0-ios'
-         - manifest: 'manifests\uno.ui.manifest.json'
+         - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net8.0-browserwasm TFM
            os: macos-12
            dotnet_version: 8.0.300
@@ -329,10 +329,10 @@ jobs:
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test default Uno template TFM's
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
-         - manifest: 'manifests\uno.ui.manifest.json'
+         - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net8.0-android\ios TFM's
            tool_params: '--tfm net8.0-android --tfm net8.0-ios'
-         - manifest: 'manifests\uno.ui.manifest.json'
+         - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net8.0-browserwasm TFM
            tool_params: '--tfm net8.0-browserwasm'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,31 +89,37 @@ jobs:
        include:
          - manifest: 'manifests\uno.ui.manifest.json'
            manifest_name: Stable
-           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32'
          - manifest: 'manifests\uno.ui-preview.manifest.json'
            manifest_name: Preview
-           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32'
          - manifest: 'manifests\uno.ui-preview-major.manifest.json'
            manifest_name: Preview net9
-           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32'
          - manifest: 'manifests\uno.ui.manifest.json'
            manifest_name: Stable Upgrade
            previous_tool_version: 1.4.2
            previous_tool_params: ''
-           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32'
          - manifest: 'manifests\uno.ui-preview.manifest.json'
            manifest_name: Preview Upgrade
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
-           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32'
          - manifest: 'manifests\uno.ui-preview-major.manifest.json'
            manifest_name: Preview Upgrade net8
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
-           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32'
          - manifest: 'manifests\uno.ui.manifest.json'
            manifest_name: Test default Uno template TFM's
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net8.0-android\ios TFM's
+           tool_params: '--tfm net8.0-android --tfm net8.0-ios'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net8.0-browserwasm TFM
+           tool_params: '--tfm net8.0-browserwasm'
 
     steps:
       - name: Checkout
@@ -163,7 +169,7 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           & dotnet --list-sdks
           & dotnet tool install --global --version ${{ steps.gitversion.outputs.semVer }} --add-source NuGet\ uno.check
-          & uno-check --ci --fix --non-interactive --verbose --manifest ${{ matrix.manifest }} ${{ matrix.tool_params }}
+          & uno-check --ci --fix --non-interactive --verbose --manifest ${{ matrix.manifest }} --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 ${{ matrix.tool_params }}
 
   testmac:
     name: Validate Tool - macOS - ${{ matrix.manifest_name }}/${{ matrix.os }}
@@ -209,6 +215,16 @@ jobs:
            os: macos-12
            dotnet_version: 8.0.300
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net8.0-android\ios TFM's
+           os: macos-12
+           dotnet_version: 8.0.300
+           tool_params: '--tfm net8.0-android --tfm net8.0-ios'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net8.0-browserwasm TFM
+           os: macos-12
+           dotnet_version: 8.0.300
+           tool_params: '--tfm net8.0-browserwasm'
         #  - manifest: 'manifests/uno.ui-preview-major.manifest.json'
         #    manifest_name: Preview Upgrade net8
         #    previous_tool_version: 1.4.2
@@ -294,31 +310,31 @@ jobs:
        include:
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Stable
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui-preview-major.manifest.json'
            manifest_name: Preview net9
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Stable Upgrade
            previous_tool_version: 1.4.2
            previous_tool_params: ''
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview Upgrade
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui-preview-major.manifest.json'
            manifest_name: Preview Upgrade net8
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test default Uno template TFM's
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net8.0-android\ios TFM's
+           tool_params: '--tfm net8.0-android --tfm net8.0-ios'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net8.0-browserwasm TFM
+           tool_params: '--tfm net8.0-browserwasm'
 
     steps:
       - name: Checkout
@@ -371,7 +387,7 @@ jobs:
           Write-Output "PACKAGE VERSION: ${{ steps.gitversion.outputs.semVer }}"
           $ProgressPreference = 'SilentlyContinue'
           & dotnet tool install --global --version ${{ steps.gitversion.outputs.semVer }} --add-source NuGet/ uno.check
-          & uno-check --ci --fix --verbose --non-interactive --verbose --manifest ${{ matrix.manifest }} ${{ matrix.tool_params }}
+          & uno-check --ci --fix --verbose --non-interactive --verbose --manifest ${{ matrix.manifest }} --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 ${{ matrix.tool_params }}
 
   sign:
     name: Sign Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,15 @@ jobs:
          - manifest: 'manifests\uno.ui.manifest.json'
            manifest_name: Test net8.0-browserwasm TFM
            tool_params: '--tfm net8.0-browserwasm'
+         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+           manifest_name: Test default Uno template TFM's with net9
+           tool_params: '--tfm net9.0-android --tfm net9.0-ios --tfm net9.0-maccatalyst --tfm net9.0-windows10.0.19041 --tfm net9.0-browserwasm --tfm net9.0-desktop'
+         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+           manifest_name: Test net9.0-android\ios TFM's
+           tool_params: '--tfm net9.0-android --tfm net9.0-ios'
+         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+           manifest_name: Test net9.0-browserwasm TFM
+           tool_params: '--tfm net9.0-browserwasm'
 
     steps:
       - name: Checkout
@@ -335,6 +344,15 @@ jobs:
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net8.0-browserwasm TFM
            tool_params: '--tfm net8.0-browserwasm'
+         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+           manifest_name: Test default Uno template TFM's with net9
+           tool_params: '--tfm net9.0-android --tfm net9.0-ios --tfm net9.0-maccatalyst --tfm net9.0-windows10.0.19041 --tfm net9.0-browserwasm --tfm net9.0-desktop'
+         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+           manifest_name: Test net9.0-android\ios TFM's
+           tool_params: '--tfm net9.0-android --tfm net9.0-ios'
+         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+           manifest_name: Test net9.0-browserwasm TFM
+           tool_params: '--tfm net9.0-browserwasm'
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,13 +336,13 @@ jobs:
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
            tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
-         - manifest: 'manifests\uno.ui.manifest.json'
+         - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test default Uno template TFM's
            tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
-         - manifest: 'manifests\uno.ui.manifest.json'
+         - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net9.0 TFM
            tool_params: '--tfm net9.0'
-         - manifest: 'manifests\uno.ui.manifest.json'
+         - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test outdated TFM's
            tool_params: '--tfm netcoreapp3.1 --tfm net452'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,22 +89,37 @@ jobs:
        include:
          - manifest: 'manifests\uno.ui.manifest.json'
            manifest_name: Stable
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests\uno.ui-preview.manifest.json'
            manifest_name: Preview
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests\uno.ui-preview-major.manifest.json'
            manifest_name: Preview net9
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests\uno.ui.manifest.json'
            manifest_name: Stable Upgrade
            previous_tool_version: 1.4.2
            previous_tool_params: ''
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests\uno.ui-preview.manifest.json'
            manifest_name: Preview Upgrade
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests\uno.ui-preview-major.manifest.json'
            manifest_name: Preview Upgrade net8
            previous_tool_version: 1.4.2
            previous_tool_params: '--pre'
+           tool_params: '--target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test default Uno template TFM's
+           tool_params: '--tfm net8.0-android --tfm net8.0-ios --tfm net8.0-maccatalyst --tfm net8.0-windows10.0.19041 --tfm net8.0-browserwasm --tfm net8.0-desktop'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net9.0 TFM
+           tool_params: '--tfm net9.0'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test outdated TFM's
+           tool_params: '--tfm netcoreapp3.1 --tfm net452'
 
     steps:
       - name: Checkout
@@ -154,7 +169,7 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           & dotnet --list-sdks
           & dotnet tool install --global --version ${{ steps.gitversion.outputs.semVer }} --add-source NuGet\ uno.check
-          & uno-check --ci --fix --non-interactive --verbose --target webassembly --target ios --target android --target macos --target linux --target win32 --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 --manifest ${{ matrix.manifest }}
+          & uno-check --ci --fix --non-interactive --verbose --manifest ${{ matrix.manifest }} ${{ matrix.tool_params }}
 
   testmac:
     name: Validate Tool - macOS - ${{ matrix.manifest_name }}/${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          dotnet test UnoCheck.Tests/UnoCheck.Tests.csproj --configuration Release --no-restore --verbosity normal
+          dotnet test UnoCheck.Tests/UnoCheck.Tests.csproj --configuration Release --verbosity normal
 
   testwin:
     name: Validate Tool - Windows - ${{ matrix.manifest_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,13 +344,13 @@ jobs:
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net8.0-browserwasm TFM
            tool_params: '--tfm net8.0-browserwasm'
-         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+         - manifest: 'manifests/uno.ui-preview-major.manifest.json'
            manifest_name: Test default Uno template TFM's with net9
            tool_params: '--tfm net9.0-android --tfm net9.0-ios --tfm net9.0-maccatalyst --tfm net9.0-windows10.0.19041 --tfm net9.0-browserwasm --tfm net9.0-desktop'
-         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+         - manifest: 'manifests/uno.ui-preview-major.manifest.json'
            manifest_name: Test net9.0-android\ios TFM's
            tool_params: '--tfm net9.0-android --tfm net9.0-ios'
-         - manifest: 'manifests\uno.ui-preview-major.manifest.json'
+         - manifest: 'manifests/uno.ui-preview-major.manifest.json'
            manifest_name: Test net9.0-browserwasm TFM
            tool_params: '--tfm net9.0-browserwasm'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,6 @@ jobs:
            manifest_name: Stable
            os: macos-12
            dotnet_version: 8.0.300
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
 
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview
@@ -190,7 +189,6 @@ jobs:
            previous_tool_params: ''
            os: macos-12
            dotnet_version: 8.0.300
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
 
         #  - manifest: 'manifests/uno.ui-preview-major.manifest.json'
         #    manifest_name: Preview net9
@@ -205,7 +203,6 @@ jobs:
            previous_tool_params: ''
            os: macos-12
            dotnet_version: 8.0.300
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
 
          - manifest: 'manifests/uno.ui-preview.manifest.json'
            manifest_name: Preview Upgrade
@@ -213,7 +210,6 @@ jobs:
            previous_tool_params: '--pre'
            os: macos-12
            dotnet_version: 8.0.300
-           tool_params: '--skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2'
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test default Uno template TFM's
            os: macos-12
@@ -302,7 +298,7 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           & dotnet --list-sdks
           & dotnet tool install --global --version ${{ steps.gitversion.outputs.semVer }} --add-source NuGet/ uno.check
-          & uno-check --ci --fix --non-interactive --verbose --manifest ${{ matrix.manifest }} ${{ matrix.tool_params }}
+          & uno-check --ci --fix --non-interactive --verbose --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 --manifest ${{ matrix.manifest }} ${{ matrix.tool_params }}
 
   testlinux:
     name: Validate Tool - Linux - ${{ matrix.manifest_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches:
       - main
@@ -18,10 +18,10 @@ on:
 env:
   GitVersion_Version: 5.10.3
 
-concurrency: 
+concurrency:
   group: ${{github.workflow}} - ${{github.ref}}
   cancel-in-progress: true
-  
+
 jobs:
   build_tool:
     name: Build
@@ -59,6 +59,25 @@ jobs:
       with:
         name: NuGet
         path: .\artifacts
+
+  run_tests:
+    name: Run Unit Tests
+    needs: build_tool
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '8.0.100'
+
+      - name: Run Tests
+        run: |
+          dotnet test UnoCheck.Tests/UnoCheck.Tests.csproj --configuration Release --no-restore --verbosity normal
 
   testwin:
     name: Validate Tool - Windows - ${{ matrix.manifest_name }}
@@ -109,7 +128,7 @@ jobs:
         uses: gittools/actions/gitversion/setup@v0.9.9
         with:
           versionSpec: ${{ env.GitVersion_Version }}
-    
+
       - name: GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.9
@@ -162,7 +181,7 @@ jobs:
         #    previous_tool_params: ''
         #    os: macos-12
         #    dotnet_version: 8.0.100
-           
+
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Stable Upgrade
            previous_tool_version: 1.17.0
@@ -208,7 +227,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
-    
+
       # Preinstall .NET as it may fail on some build agents
       - name: Setup .NET Core ${{ matrix.dotnet_version }}
         uses: actions/setup-dotnet@v1
@@ -224,7 +243,7 @@ jobs:
         uses: gittools/actions/gitversion/setup@v0.9.9
         with:
           versionSpec: ${{ env.GitVersion_Version }}
-    
+
       - name: GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.9
@@ -266,7 +285,7 @@ jobs:
            manifest_name: Preview
          - manifest: 'manifests/uno.ui-preview-major.manifest.json'
            manifest_name: Preview net9
-           
+
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Stable Upgrade
            previous_tool_version: 1.4.2
@@ -301,7 +320,7 @@ jobs:
         uses: gittools/actions/gitversion/setup@v0.9.9
         with:
           versionSpec: ${{ env.GitVersion_Version }}
-    
+
       - name: GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.9
@@ -332,7 +351,7 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           & dotnet tool install --global --version ${{ steps.gitversion.outputs.semVer }} --add-source NuGet/ uno.check
           & uno-check --ci --fix --verbose --non-interactive --verbose --skip xcode --skip vswin --skip vsmac --skip wsl --skip edgewebview2 --manifest ${{ matrix.manifest }}
-  
+
   sign:
     name: Sign Package
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}

--- a/UnoCheck.Tests/CheckCommandTests.cs
+++ b/UnoCheck.Tests/CheckCommandTests.cs
@@ -1,0 +1,55 @@
+using System.Runtime.InteropServices;
+using DotNetCheck;
+using DotNetCheck.Cli;
+
+namespace UnoCheck.Tests;
+
+public class CheckCommandTests
+{
+    [Theory]
+    [InlineData("netcoreapp3.1")]
+    [InlineData("net481")]
+    [InlineData("netstandard2.1")]
+    public void ParseTfmsToTargetPlatforms_Returns_Empty_Collection_For_NotSupported_TFM(params string[] tfms)
+    {
+        var platformsToInclude = CheckCommand.ParseTfmsToTargetPlatforms(new CheckSettings { Frameworks = tfms });
+        Assert.Empty(platformsToInclude);
+    }
+    
+    [Theory]
+    [InlineData("net5.0")]
+    [InlineData("net6.0")]
+    [InlineData("net7.0")]
+    [InlineData("net8.0")]
+    [InlineData("net9.0")]
+    public void ParseTfmsToTargetPlatforms_Returns_Empty_Collection_For_Not_OS_Specific_TFMs(params string[] tfms)
+    {
+        var platformsToInclude = CheckCommand.ParseTfmsToTargetPlatforms(new CheckSettings { Frameworks = tfms });
+        Assert.Empty(platformsToInclude);
+    }
+    
+    [Fact]
+    public void ParseTfmsToTargetPlatforms_Returns_Correct_Values_For_OS_Specific_TFMs()
+    {
+        var platformsToInclude = CheckCommand.ParseTfmsToTargetPlatforms(new CheckSettings { Frameworks =
+            ["net8.0-windows10.0.19041", "net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-browserwasm"]
+        });
+        Assert.Equal(platformsToInclude, ["windows", "android", "ios", "macos", "web"]);
+        
+        platformsToInclude = CheckCommand.ParseTfmsToTargetPlatforms(new CheckSettings { Frameworks =
+            ["net8.0-windows10.0.19041", "net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-browserwasm", "net8.0-desktop"]
+        });
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Equal(platformsToInclude, ["windows", "android", "ios", "macos", "web", "win32"]);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            Assert.Equal(platformsToInclude, ["windows", "android", "ios", "macos", "web", "macos"]);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            Assert.Equal(platformsToInclude, ["windows", "android", "ios", "macos", "web", "linux"]);
+        }
+    }
+}

--- a/UnoCheck.Tests/UnoCheck.Tests.csproj
+++ b/UnoCheck.Tests/UnoCheck.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\UnoCheck\UnoCheck.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/UnoCheck.sln
+++ b/UnoCheck.sln
@@ -14,6 +14,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnoCheck", "UnoCheck\UnoChe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.MSBuildSdkResolver", "UnoCheck.SdkResolver\Microsoft.DotNet.MSBuildSdkResolver.csproj", "{DD9F230A-D328-4F90-B030-D27035D365DA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnoCheck.Tests", "UnoCheck.Tests\UnoCheck.Tests.csproj", "{3A9041CD-1B60-4BA1-8C45-2F031845D587}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{DD9F230A-D328-4F90-B030-D27035D365DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DD9F230A-D328-4F90-B030-D27035D365DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DD9F230A-D328-4F90-B030-D27035D365DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A9041CD-1B60-4BA1-8C45-2F031845D587}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A9041CD-1B60-4BA1-8C45-2F031845D587}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A9041CD-1B60-4BA1-8C45-2F031845D587}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A9041CD-1B60-4BA1-8C45-2F031845D587}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
 
@@ -388,7 +389,18 @@ namespace DotNetCheck.Cli
                             targetPlatforms.Add("windows");
                             break;
                         case "desktop":
-                            targetPlatforms.Add("win32");
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                            {
+                                targetPlatforms.Add("win32");   
+                            }
+                            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                            {
+                                targetPlatforms.Add("macos");
+                            }
+                            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                            {
+                                targetPlatforms.Add("linux");
+                            }
                             break;
                         case "ios":
                             targetPlatforms.Add("ios");

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -1,6 +1,4 @@
-﻿using DotNetCheck.Checkups;
-using DotNetCheck.Models;
-using NuGet.Configuration;
+﻿using DotNetCheck.Models;
 using NuGet.Versioning;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -8,9 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
+
+[assembly: InternalsVisibleTo("UnoCheck.Tests")]
 
 namespace DotNetCheck.Cli
 {
@@ -313,6 +314,59 @@ namespace DotNetCheck.Cli
 
 			return exitCode;
 		}
+        
+        internal static string[] ParseTfmsToTargetPlatforms(CheckSettings settings)
+        {
+            var targetPlatforms = new List<string>();
+            foreach (var tfm in settings.Frameworks!)
+            {
+                var parsedTfm = NuGetFramework.ParseFolder(tfm);
+
+                if (parsedTfm.Version.Major >= 5 && parsedTfm.HasPlatform == false)
+                {
+                    // Returning empty list which means that we will target all platforms.
+                    return [];
+                } 
+                if (parsedTfm.HasPlatform)
+                {
+                    switch (parsedTfm.Platform)
+                    {
+                        case "windows":
+                            targetPlatforms.Add("windows");
+                            break;
+                        case "desktop":
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                            {
+                                targetPlatforms.Add("win32");   
+                            }
+                            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                            {
+                                targetPlatforms.Add("macos");
+                            }
+                            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                            {
+                                targetPlatforms.Add("linux");
+                            }
+                            break;
+                        case "ios":
+                            targetPlatforms.Add("ios");
+                            break;
+                        case "android":
+                            targetPlatforms.Add("android");
+                            break;
+                        case "macos":
+                        case "maccatalyst":
+                            targetPlatforms.Add("macos");
+                            break;
+                        case "browserwasm":
+                            targetPlatforms.Add("web");
+                            break;
+                    }
+                }
+                
+            }
+            return targetPlatforms.ToArray();
+        }
 
 		private async Task<bool> NeedsToolUpdateAsync(CheckSettings settings)
 		{
@@ -368,59 +422,6 @@ namespace DotNetCheck.Cli
 
 			AnsiConsole.MarkupLine("  " + msg);
 		}
-
-        private string[] ParseTfmsToTargetPlatforms(CheckSettings settings)
-        {
-            var targetPlatforms = new List<string>();
-            foreach (var tfm in settings.Frameworks!)
-            {
-                var parsedTfm = NuGetFramework.ParseFolder(tfm);
-
-                if (parsedTfm.Version.Major >= 5 && parsedTfm.HasPlatform == false)
-                {
-                    // Returning empty list which means that we will target all platforms.
-                    return [];
-                } 
-                if (parsedTfm.HasPlatform)
-                {
-                    switch (parsedTfm.Platform)
-                    {
-                        case "windows":
-                            targetPlatforms.Add("windows");
-                            break;
-                        case "desktop":
-                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                            {
-                                targetPlatforms.Add("win32");   
-                            }
-                            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                            {
-                                targetPlatforms.Add("macos");
-                            }
-                            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                            {
-                                targetPlatforms.Add("linux");
-                            }
-                            break;
-                        case "ios":
-                            targetPlatforms.Add("ios");
-                            break;
-                        case "android":
-                            targetPlatforms.Add("android");
-                            break;
-                        case "macos":
-                        case "maccatalyst":
-                            targetPlatforms.Add("macos");
-                            break;
-                        case "browserwasm":
-                            targetPlatforms.Add("web");
-                            break;
-                    }
-                }
-                
-            }
-            return targetPlatforms.ToArray();
-        }
         
 		private void RemedyStatusUpdated(object sender, RemedyStatusEventArgs e)
 		{

--- a/UnoCheck/CheckSettings.Uno.cs
+++ b/UnoCheck/CheckSettings.Uno.cs
@@ -16,5 +16,10 @@ namespace DotNetCheck
 Targets: webassembly ios android macos linux windows"
 			)]
 		public string[]? TargetPlatforms { get; set; }
+        
+        [CommandOption("--tfm <TARGET_FRAMEWORK>")]
+        [Description(
+            @"Run checks for a specific TFM. Use the --framework option multiple times to run checks for multiple TFM's, or omit it to run checks for all supported platforms.")]
+        public string[]? Frameworks { get; set; }
 	}
 }

--- a/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
@@ -44,6 +44,7 @@ namespace DotNetCheck.Checkups
                     case "ios" when TargetPlatforms.HasFlag(TargetPlatform.iOS):
                     case "macos" when TargetPlatforms.HasFlag(TargetPlatform.macOS):
                     case "maccatalyst" when TargetPlatforms.HasFlag(TargetPlatform.macOS):
+                    case "wasm-tools" when TargetPlatforms.HasFlag(TargetPlatform.WebAssembly):
                         return true;
                 }
                 

--- a/UnoCheck/UnoCheck.csproj
+++ b/UnoCheck/UnoCheck.csproj
@@ -33,6 +33,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.11.0" />
 		<PackageReference Include="NuGet.Packaging" Version="5.11.5" />
 		<PackageReference Include="NuGet.Protocol" Version="5.11.5" />
 		<PackageReference Include="NuGet.Versioning" Version="5.11.5" />


### PR DESCRIPTION
The idea behind that feature is to parse the TFM's and transform them into the TargetPlatforms since we already have all the needed infra for that. So now we can just pass the TFM's from the IDE's with `--tfm mytfm`  and add `--ci --non-interactive` just to get the read-only output and uno-check could probably be used for the IDE integration after that.
Fixes #286 