### PR TITLE
fix: Use bash on macos

### DIFF
--- a/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
+++ b/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
@@ -51,7 +51,7 @@ namespace DotNetCheck.Solutions
 			var exe = Util.Platform switch
 			{
 				Platform.Linux => "bash",
-				Platform.OSX => "sh",
+				Platform.OSX => "bash",
 				Platform.Windows => "powershell",
 				_ => throw new NotSupportedException($"Unsupported platform {Util.Platform}")
 			};


### PR DESCRIPTION
The latest update of dotnet-install.sh explicitly uses bash options