### PR TITLE
Version bump after 1.28 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.28-dev.{height}",
-  "versionHeightOffset": 50,
+  "version": "1.29-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION

This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/1.28, based on #329