### PR TITLE
fix: Update skips logic

### DIFF
--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -348,7 +348,7 @@ namespace DotNetCheck.Cli
 
                 // For all TFM's besides net8.0 we skip these checks.
                 // https://github.com/unoplatform/private/issues/506
-                if (parsedTfm.Version.Major == 8)
+                if (parsedTfm.Version.Major < 9)
                 {
 	                var skips = settings.Skip?.ToList() ?? [];
 	                settings.Skip = skips.Except(["git", "linuxninja", "psexecpolicy", "windowspyhtonInstallation"]).Distinct().ToArray();

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Spectre.Console;
@@ -9,9 +10,17 @@ namespace DotNetCheck
 {
 	public class Util
 	{
-        public static string[] RiderSkips = ["vswin","vswinworkloads", "dotnetnewunotemplates"];
+		public static string[] BaseSkips = ["git", "linuxninja", "psexecpolicy", "windowspyhtonInstallation"];
+        public static string[] RiderSkips = ["vswin","vswinworkloads"];
         public static string[] VSCodeSkips = ["vswin","vswinworkloads"];
-        public static string[] VSSkips = ["dotnetnewunotemplates"];
+        public static string[] VSSkips = ["vswin","vswinworkloads"];
+
+        public static void UpdateSkips(CheckSettings settings, string[] skips)
+        {
+	        var currentSkips = settings.Skip?.ToList() ?? [];
+	        currentSkips.AddRange(skips);
+	        settings.Skip = currentSkips.Distinct().ToArray();
+        }
 		public static void LogAlways(string message)
 		{
 			Console.WriteLine(message);


### PR DESCRIPTION
This PR updates check skips according to https://github.com/unoplatform/private/issues/506
Git\Ninja\Powershell\Python are always disabled when --tfm isn't specified and when tfm is not net8.0 based.
When uno.check is called from IDE we now only skip "vswin","vswinworkloads" for all IDE's. Logic related to the "dotnet new" check will be added in each IDE code separately