### PR TITLE
Version bump after 1.29 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.29-dev.{height}",
+  "version": "1.30-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This will allow uno.check to install the uno.sdk version needed by the solution when integrating ith IDE's
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/1.29, based on #337