### PR TITLE
feat: Add a GitHub Actions workflow for use in CI workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,51 @@
+name: Uno.Check
+description: "GitHub Action to setup a remote environment to build Uno Platform apps"
+
+branding:
+  icon: 'download'
+  color: 'red'
+
+inputs:
+  target-platform:
+    description: 'The platform to install dependencies for. See available values at https://platform.uno/docs/articles/external/uno.check/doc/using-uno-check.html'
+    required: false
+    default: 'all'
+  dotnet-version:
+    description: 'Installs and sets the .NET SDK Version'
+    required: false
+    default: '9.0.x'
+  sdkVersion:
+    description: 'The version of the Windows Sdk'
+    required: false
+    default: '19041'
+
+runs:
+  using: "composite"
+  steps:
+    # Install .NET
+    - name: Setup .NET ${{ inputs.dotnet-version }}
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '${{ inputs.dotnet-version }}'
+
+    # Install Windows SDK
+    - name: Install Windows SDK ${{ inputs.sdkVersion }}
+      shell: pwsh
+      if: ${{ runner.os == 'Windows' }}
+      uses: Lamparter/Install-WindowsSdk@v1.0.0
+      with:
+        buildNumber: '${{ inputs.sdkVersion }}'
+
+    # Run Uno.Check
+    - name: Install ${{ inputs.target-platform }} Workloads
+      shell: pwsh
+      run: |
+        dotnet tool install -g uno.check
+        ("${{ inputs.target-platform }} ".Split(' ') | ForEach-Object {
+          $target = $_.Replace("_win", "").Replace("_macos", "")
+          if (![string]::IsNullOrEmpty($target)) {
+            echo "target: $target"
+            uno-check -v --ci --non-interactive --fix --target $target --skip vswin --skip vsmac --skip xcode --skip vswinworkloads --skip androidemulator --skip dotnetnewunotemplates
+            echo "uno-check finished for target: $target "
+          }
+        })


### PR DESCRIPTION
This PR implements an alternative way for consuming Uno.Check - from GitHub Actions.
This will appear in the GitHub Marketplace once a release on the repo is published or a tag is created.

This also removes the need for the massive unnecessary workflow files shipped with the Uno templates wizard downstream.

---

```yml
name: Example Workflow
on: [push]

jobs:
  build:
    runs-on: windows-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@v4
      - name: Install Uno Platform workload
        uses: unoplatform/uno.check@[version]
        with:
          target-platform: 'all'
          dotnet-version: '8.0.x'
          sdk-version: '19041'
```