### PR TITLE
docs(targetplatforms): Updated and improved target platforms

### DIFF
--- a/UnoCheck/TargetPlatformHelper.cs
+++ b/UnoCheck/TargetPlatformHelper.cs
@@ -44,9 +44,10 @@ namespace DotNetCheck
 					return TargetPlatform.Android;
 				case "macos":
 					return TargetPlatform.macOS;
-                case "windows":
+                case "winappsdk":
                 case "wasdk":
 					return TargetPlatform.WinAppSDK;
+                case "windows":
                 case "win32desktop":
                 case "win32":
                     return TargetPlatform.Windows;

--- a/UnoCheck/TargetPlatformHelper.cs
+++ b/UnoCheck/TargetPlatformHelper.cs
@@ -24,11 +24,16 @@ namespace DotNetCheck
 
 			return output;
 		}
-
+        /// <summary>
+        /// Converts the string provided uno-check input argument to the corresponding <see cref="TargetPlatform"/>
+        /// </summary>
+        /// <param name="flag">The user-provided argument as <see langword="string"/></param>
+        /// <returns>The <see cref="TargetPlatform"/> from the <paramref name="flag"/></returns>
 		public static TargetPlatform GetTargetPlatformFromFlag(string flag)
 		{
 			switch (flag.ToLowerInvariant())
 			{
+                case "web":
 				case "webassembly":
 				case "wasm":
 					return TargetPlatform.WebAssembly;
@@ -39,24 +44,19 @@ namespace DotNetCheck
 					return TargetPlatform.Android;
 				case "macos":
 					return TargetPlatform.macOS;
-				case "skiadesktop":
-					return TargetPlatform.SkiaDesktop;
                 case "windows":
                 case "wasdk":
 					return TargetPlatform.WinAppSDK;
                 case "win32desktop":
                 case "win32":
                     return TargetPlatform.Windows;
+                case "skiadesktop":
 				case "skia":
 					return TargetPlatform.SkiaDesktop;
 				case "linux":
 					return TargetPlatform.SkiaDesktop;
-				case "web":
-					return TargetPlatform.WebAssembly;
-
 				case "all":
 					return TargetPlatform.All;
-
 				default:
 					return TargetPlatform.None;
 			}

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -60,6 +60,10 @@ So, for example, the following will only check your environment for web and Linu
 uno-check --target wasm --target linux
 ```
 
+> [!Note:]
+> When specifying multiple target platforms, each element must be preceded by --target.
+> It is not possible to list multiple values without this prefix.
+
 The following argument values for `--target` are supported:
 
 | Value     | Comments          |

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -8,21 +8,21 @@ uid: UnoCheck.Configuration
 
 It is possible to run Uno.Check to setup your build environment in a repeatable way by using the following commands:
 
-# [**Windows**](#tab/windows)
+## [**Windows**](#tab/windows)
 
 ```bash
 dotnet tool install --global Uno.Check --version 1.29.4
 uno-check -v --ci --non-interactive --fix --skip vswin --skip androidemulator --skip androidsdk
 ```
 
-# [**macOS**](#tab/macos)
+## [**macOS**](#tab/macos)
 
 ```bash
 dotnet tool install --global Uno.Check --version 1.29.4
 uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip androidsdk
 ```
 
-# [**Linux**](#tab/linux)
+## [**Linux**](#tab/linux)
 
 ```bash
 dotnet tool install --global Uno.Check --version 1.29.4

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -11,22 +11,21 @@ It is possible to run Uno.Check to setup your build environment in a repeatable 
 # [**Windows**](#tab/windows)
 
 ```bash
-dotnet tool install --global Uno.Check --version 1.20.0
+dotnet tool install --global Uno.Check --version 1.29.4
 uno-check -v --ci --non-interactive --fix --skip vswin --skip androidemulator --skip androidsdk
 ```
 
 # [**macOS**](#tab/macos)
 
 ```bash
-dotnet tool install --global Uno.Check --version 1.20.0
+dotnet tool install --global Uno.Check --version 1.29.4
 uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip androidsdk
 ```
-
 
 # [**Linux**](#tab/linux)
 
 ```bash
-dotnet tool install --global Uno.Check --version 1.20.0
+dotnet tool install --global Uno.Check --version 1.29.4
 uno-check -v --ci --non-interactive --fix --skip androidemulator
 ```
 

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -64,19 +64,18 @@ uno-check --target wasm --target linux
 > When specifying multiple target platforms, each element must be preceded by --target.
 > It is not possible to list multiple values without this prefix.
 
-The following argument values for `--target` are supported:
+Supported target platforms and their `--target` values:
 
-| Value     | Comments          |
-|-----------|-------------------|
-| wasm      |                   |
-| ios       |                   |
-| android   |                   |
-| macos     |                   |
-| linux     |                   |
-| skiawpf   |                   |
-| uwp       |                   |
-| win32     |                   |
-| all       | All platforms     |
+| Target Platform  | Input Values                       |
+|------------------|------------------------------------|
+| WebAssembly      | `web`, `webassembly`, `wasm`       |
+| iOS              | `ios`                              |
+| Android          | `android`, `droid`                 |
+| macOS            | `macos`                            |
+| SkiaDesktop      | `skiadesktop`, `skia`, `linux`     |
+| WinAppSDK        | `winappsdk`, `wasdk`               |
+| Windows          | `windows`, `win32desktop`, `win32` |
+| All Platforms    | `all`                              |
 
 ### `-m <FILE_OR_URL>`, `--manifest <FILE_OR_URL>` Manifest File or Url
 


### PR DESCRIPTION
# Content of this PR

## 1. Updated the TargetPlattformsHelper.GetTargetPlatformFlags

- Reordered the case statements so the same result groups for brevity
- fixed the `windows` case to match the to be expected result! So far it had been pointing to TargetPlatform.WindowsAppSDK instead of its logical result of TargetPlatform.Windows.
- added the case `winappsdk` as alternative to the current `wasdk`, because of the existing `wasdk` could/can be mistaken with the `wasm` as the actual WebAssembly target. For those who are not common with the shortcuts of target names this current one has been a potentional problem source. Remark: I did not remove the `wasdk` !

## 2. Updated the corresponding Documentation configuring-uno-check

- telling about its the available options including above mentioned ones
- added a note explicitly telling to use the `--target` as prefix before each of the wanted platforms as I seen the hint for this only in the xml in the code itself
- re-formatted the values table to improve the layout and understandability which options to choose for which of the results

PR closes issue #322

# Participation / Help on this PR required for this parts of the initial issue:

- [ ] 1. the `uno-check --help` output description for the target values should to be updated to also provide a full list of options of targets with its corresponding available values.

Reason why I did not include this so far is, I don't know how to create actual output like this:
    - Input: `uno-check --target --help` (or switched positions)
    - Current Output: (same for the mentioned input from above happened before)
    
![image](https://github.com/user-attachments/assets/2d68b187-68a7-4626-865d-aaa9ab4dba5e)

- Targeted Output: (see the table in the documentation I updated) just as list as it is common for other cli tools to be able to provide
