### PR TITLE
fix: iOS SDK check avoiding false positive

### DIFF
--- a/UnoCheck/Checkups/XCodeCheckup.cs
+++ b/UnoCheck/Checkups/XCodeCheckup.cs
@@ -50,22 +50,6 @@ namespace DotNetCheck.Checkups
 
 				if (selected is not null && selected.Version.IsCompatible(MinimumVersion, ExactVersion))
 				{
-					// customize runner options so the license can be displayed
-					var options = new ShellProcessRunnerOptions("xcodebuild", "");
-					var runner = new ShellProcessRunner(options);
-					var result = runner.WaitForExit();
-					// Check if user requires EULA to be accepted
-					if (result.ExitCode == 69)
-					{
-						Spectre.Console.AnsiConsole.MarkupLine("[bold red]By fixing this you are accepting the license agreement.[/]");
-						return Task.FromResult(new DiagnosticResult(
-							Status.Error,
-							this,
-							new Suggestion("Run `sudo xcodebuild -license accept`",
-								new Solutions.XcodeEulaSolution())));
-					}
-
-					//before returning we want to validate that the iOS SDK is installed
 					if (!ValidateForiOSSDK())
 					{
 						ReportStatus($"Xcode.app ({selected.VersionString} {selected.BuildVersion}) is installed, but missing the iOS SDK. Usually, this occurs after a recent Xcode install or update.", Status.Error);
@@ -81,6 +65,21 @@ namespace DotNetCheck.Checkups
 									ShellProcessRunner.Run("open", $"-a {selected.Path}");
 									return Task.CompletedTask;
 								}))));
+					}
+
+					// customize runner options so the license can be displayed
+					var options = new ShellProcessRunnerOptions("xcodebuild", "");
+					var runner = new ShellProcessRunner(options);
+					var result = runner.WaitForExit();
+					// Check if user requires EULA to be accepted
+					if (result.ExitCode == 69)
+					{
+						Spectre.Console.AnsiConsole.MarkupLine("[bold red]By fixing this you are accepting the license agreement.[/]");
+						return Task.FromResult(new DiagnosticResult(
+							Status.Error,
+							this,
+							new Suggestion("Run `sudo xcodebuild -license accept`",
+								new Solutions.XcodeEulaSolution())));
 					}
 
 					// Selected version is good

--- a/UnoCheck/Checkups/XCodeCheckup.cs
+++ b/UnoCheck/Checkups/XCodeCheckup.cs
@@ -245,7 +245,9 @@ namespace DotNetCheck.Checkups
 						var p = ShellProcessRunner.Run("xcrun", $"simctl list runtimes ios available | grep {settings.Version}");
 						var runtimeOutput = p.GetOutput().Trim();
 
-						return !string.IsNullOrEmpty(runtimeOutput);
+						Util.Log($"Found iOS Runtime: {runtimeOutput}");
+
+						return !string.IsNullOrEmpty(runtimeOutput) && runtimeOutput.Contains(settings.Version);
 					}
 				}
 			}

--- a/UnoCheck/Checkups/XCodeCheckup.cs
+++ b/UnoCheck/Checkups/XCodeCheckup.cs
@@ -80,7 +80,7 @@ namespace DotNetCheck.Checkups
 									ShellProcessRunner.Run("open", $"-a {selected.Path}");
 									return Task.CompletedTask;
 								}))));
-					}					
+					}
 
 					// Selected version is good
 					ReportStatus($"Xcode.app ({selected.VersionString} {selected.BuildVersion})", Status.Ok);
@@ -216,7 +216,7 @@ namespace DotNetCheck.Checkups
 			return null;
 		}
 
-		// Checking iOS SDK is a three step process:
+		// Checking iOS SDK is a three-step process:
 		// 1. Get the path to the iOS SDK using `xcrun -sdk iphonesimulator --show-sdk-path`
 		// 2. Find the SDK Version in the SDKSettings.json file located at the SDK path
 		// 3. Filter the iOS Runtime installed using the SDK Version

--- a/UnoCheck/Checkups/XCodeCheckup.cs
+++ b/UnoCheck/Checkups/XCodeCheckup.cs
@@ -66,7 +66,7 @@ namespace DotNetCheck.Checkups
 					}
 
 					//before returning we want to validate that the iOS SDK is installed
-					if (!ValidateForiOSSDK(selected))
+					if (!ValidateForiOSSDK())
 					{
 						ReportStatus($"Xcode.app ({selected.VersionString} {selected.BuildVersion}) is installed, but missing the iOS SDK. Usually, this occurs after a recent Xcode install or update.", Status.Error);
 
@@ -217,17 +217,10 @@ namespace DotNetCheck.Checkups
 			return null;
 		}
 
-		static bool ValidateForiOSSDK(XCodeInfo selected)
+		static bool ValidateForiOSSDK()
 		{
-			var iphoneSimulatorSDKPath = Path.Combine(selected.Path, "Contents", "Developer", "Platforms", "iPhoneSimulator.platform", "Developer", "SDKs", "iPhoneSimulator.sdk");
-
-			if (Directory.Exists(iphoneSimulatorSDKPath))
-			{
-				return true;
-			}
-
 			var r = ShellProcessRunner.Run("xcrun", "-sdk iphonesimulator --show-sdk-path");
-			iphoneSimulatorSDKPath = r.GetOutput().Trim();
+			var iphoneSimulatorSDKPath = r.GetOutput().Trim();
 
 			return Directory.Exists(iphoneSimulatorSDKPath);
 		}


### PR DESCRIPTION
Fix iOS SDK validation. Previous validation would give false positives when different iOS simulators were installed.