### PR TITLE
feat: Add auto-updating

### DIFF
--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -42,7 +42,7 @@ namespace DotNetCheck.Cli
 			AnsiConsole.MarkupLine("If problems are detected, it will offer the option to try and fix them for you, or suggest a way to fix them yourself.");
 			AnsiConsole.Write(new Rule());
 
-			if (await NeedsToolUpdateAsync(settings))
+			if (await ToolUpdater.CheckAndPromptForUpdateAsync(settings))
 			{
 				return 1;
 			}
@@ -432,46 +432,6 @@ namespace DotNetCheck.Cli
             }
             return targetPlatforms.ToArray();
         }
-
-		private async Task<bool> NeedsToolUpdateAsync(CheckSettings settings)
-		{
-			if ( (settings.Manifest is not null && !settings.CI) || Debugger.IsAttached)
-			{
-				return false;
-			}
-
-			bool needsToUpdate = false;
-			var currentVersion = ToolInfo.CurrentVersion;
-			NuGetVersion latestVersion = null;
-			try
-			{
-				latestVersion = await ToolInfo.GetLatestVersion(currentVersion.IsPrerelease);
-			}
-			catch
-			{
-				AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Could not check for latest version of uno-check on NuGet.org. The currently installed version may be out of date.[/]");
-				AnsiConsole.WriteLine();
-				AnsiConsole.Write(new Rule());
-			}
-
-			if (latestVersion is not null && currentVersion < latestVersion)
-			{
-				AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Your uno-check version is not up to date. The latest version is {latestVersion}. You can use the following command to update:[/]");
-				AnsiConsole.WriteLine();
-				AnsiConsole.MarkupLine($"dotnet tool update --global Uno.Check --version {latestVersion}");
-				AnsiConsole.WriteLine();
-
-				AnsiConsole.Write(new Rule());
-			}
-
-			if (!settings.CI && (latestVersion is null || currentVersion < latestVersion))
-			{
-				var shouldContinue = AnsiConsole.Confirm("Would you still like to continue with the currently installed version?", false);
-				needsToUpdate = !shouldContinue;
-            }
-
-			return needsToUpdate;
-		}
 
 		private void CheckupStatusUpdated(object sender, CheckupStatusEventArgs e)
 		{

--- a/UnoCheck/ToolUpdater.cs
+++ b/UnoCheck/ToolUpdater.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+using Spectre.Console;
+
+namespace DotNetCheck;
+
+internal static class ToolUpdater
+{
+    private enum UserAction
+    {
+        Continue,
+        Update,
+        Stop
+    }
+
+    public static async Task<bool> CheckAndPromptForUpdateAsync(CheckSettings settings)
+    {
+        if ((settings.Manifest is not null && !settings.CI) || Debugger.IsAttached)
+        {
+            return false;
+        }
+        
+        var currentVersion = ToolInfo.CurrentVersion;
+        NuGetVersion latestVersion = null;
+
+        try
+        {
+            latestVersion = await ToolInfo.GetLatestVersion(currentVersion.IsPrerelease);
+        }
+        catch
+        {
+            AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Could not check for latest version on NuGet.org. The currently installed version may be out of date.[/]");
+            AnsiConsole.WriteLine();
+            AnsiConsole.Write(new Rule());
+        }
+
+        if (latestVersion is not null && currentVersion < latestVersion)
+        {
+            AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Your uno-check version is not up to date. The latest version is {latestVersion}. You can update with:[/]");
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine($"dotnet tool update --global {ToolInfo.ToolPackageId} --version {latestVersion}");
+            AnsiConsole.WriteLine();
+            AnsiConsole.Write(new Rule());
+        }
+        
+        if (!settings.CI && (latestVersion is null || currentVersion < latestVersion))
+        {
+            var action = AnsiConsole.Prompt(
+                new SelectionPrompt<UserAction>()
+                    .Title("What would you like to do?")
+                    .AddChoices(UserAction.Continue, UserAction.Update, UserAction.Stop)
+                    .UseConverter(action => action switch
+                    {
+                        UserAction.Continue => "[green]Continue[/]",
+                        UserAction.Update => "[yellow]Update[/]",
+                        UserAction.Stop => "[red]Stop[/]",
+                        _ => action.ToString()
+                    })
+                    .PageSize(3)
+            );
+
+            if (action == UserAction.Update)
+            {
+                RelaunchWithUpdate(latestVersion?.ToString() ?? currentVersion.ToString());
+            }
+
+            return action == UserAction.Stop;
+        }
+
+        return false;
+    }
+
+    private static void RelaunchWithUpdate(string version)
+    {
+        var argsLine = string.Join(" ", 
+            Environment.GetCommandLineArgs().Skip(1)
+                   .Select(a => a.Contains(' ') ? $"\"{a}\"" : a)
+        );
+
+        PerformUpdateAndRelaunch(version, argsLine);
+    }
+
+    private static void PerformUpdateAndRelaunch(string version, string argsForRelaunch)
+    {
+        if (Util.IsWindows)
+        {
+            var cmdText =
+                $"timeout /T 2 /NOBREAK && " +
+                $"dotnet tool update --global {ToolInfo.ToolPackageId} --version {version} " +
+                $"&& start \"\" {ToolInfo.ToolCommand} {argsForRelaunch}";
+
+            Process.Start(new ProcessStartInfo("cmd.exe", $"/C {cmdText}")
+            {
+                UseShellExecute  = true,
+                CreateNoWindow   = true,
+                WindowStyle = ProcessWindowStyle.Hidden
+            });
+        }
+        else
+        {
+            var shCommand =
+                $"sleep 2 && " +
+                $"dotnet tool update --global {ToolInfo.ToolPackageId} --version {version} " +
+                $"&& {ToolInfo.ToolCommand} {argsForRelaunch}";
+            var full = $"nohup sh -c \"{shCommand}\" >/dev/null 2>&1 &";
+
+            Process.Start(new ProcessStartInfo("/bin/sh", $"-c \"{full}\"")
+            {
+                UseShellExecute  = false,
+                CreateNoWindow   = true,
+                WindowStyle = ProcessWindowStyle.Hidden
+            });
+        }
+        
+        Environment.Exit(0);
+    }
+}


### PR DESCRIPTION
When user clicks "Update" the tool will auto-update itself.
![image](https://github.com/user-attachments/assets/4493d89b-5bc9-49a6-949e-96fcf5790ee8)
The tool will create a separate process and kill itself. In a separate process we wait for 2 seconds so the process won't be busy, update the tool and restart. Tested on Win, need to validate on unix.

Fixes https://github.com/unoplatform/uno.vscode/issues/950 and https://github.com/unoplatform/uno.studio/issues/781