### PR TITLE
chore: Add --version parameter support

### DIFF
--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using DotNetCheck.Checkups;
@@ -51,6 +51,12 @@ namespace DotNetCheck
 
 			app.Configure(config =>
 			{
+                var version = ToolInfo.CurrentVersion;
+                var buildDate = File.GetLastWriteTime(typeof(ToolInfo).Assembly.Location)
+                    .ToString("yyyy-MM-dd");
+                var versionText = $"Uno.Check Version {version} (built {buildDate})";
+                config.SetApplicationName(ToolInfo.ToolCommand);
+                config.SetApplicationVersion(versionText);
 				config.AddCommand<CheckCommand>("check");
 				config.AddCommand<ListCheckupCommand>("list");
 				config.AddCommand<ConfigCommand>("config");
@@ -59,8 +65,8 @@ namespace DotNetCheck
 			var finalArgs = new List<string>();
 
 			var firstArg = args?.FirstOrDefault()?.Trim()?.ToLowerInvariant() ?? string.Empty;
-
-			if (firstArg != "list" && firstArg != "config" && firstArg != "acquirepackages")
+            bool isGlobalOption = firstArg is "-h" or "--help" or "-v" or "--version";
+            if (!isGlobalOption && firstArg != "list" && firstArg != "config" && firstArg != "acquirepackages")
 				finalArgs.Add("check");
 
 			if (args?.Any() ?? false)

--- a/UnoCheck/UnoCheck.csproj
+++ b/UnoCheck/UnoCheck.csproj
@@ -39,7 +39,7 @@
 		<PackageReference Include="NuGet.Versioning" Version="5.11.5" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.46.1-preview.0.6" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
 		<PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
 		<PackageReference Include="System.Text.Json" Version="5.0.2" />
@@ -49,7 +49,7 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="plist-cil" Version="2.2.0" />
-		<PackageReference Include="Spectre.Console" Version="0.46.1-preview.0.6" />
+		<PackageReference Include="Spectre.Console" Version="0.50.0" />
 		<PackageReference Include="Xamarin.LibZipSharp" Version="2.0.0" />
 		<PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" Condition=" '$(OS)' != 'Windows_NT' " />
 		<PackageReference Include="ini-parser-netstandard" Version="2.5.2" />


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/22685707-a355-42ad-9b95-abe7e868458f)

*Spectre.Console* and *Spectre.Console.Cli* were updated since latest versions of those packages have some fixes for `-v|--version` parameter.
Also setting `SetApplicationName` so when you write
`
uno-check -h
` 
you will see
`
Usage: uno-check [OPTIONS] <COMMAND>
`
instead of 
`
Usage: UnoCheck.dll [OPTIONS] <COMMAND>
`
Fixes #378 