### PR TITLE
feat: Add checkup to trust https dev certs

### DIFF
--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -27,6 +27,7 @@ namespace DotNetCheck.Cli
 			Util.CI = settings.CI;
 			if (settings.CI)
 				settings.NonInteractive = true;
+			Util.NonInteractive = settings.NonInteractive;
 
 			Console.Title = ToolInfo.ToolName;
 

--- a/UnoCheck/Checkups/HttpsDevCertCheckup.cs
+++ b/UnoCheck/Checkups/HttpsDevCertCheckup.cs
@@ -12,8 +12,7 @@ namespace DotNetCheck.Checkups
 
         // Only examine when WebAssembly is one of the targets
         public override bool ShouldExamine(SharedState history) => 
-            !Util.CI && !Util.NonInteractive
-            && history.TryGetState<TargetPlatform>(StateKey.EntryPoint, StateKey.TargetPlatforms, out var platforms)
+            history.TryGetState<TargetPlatform>(StateKey.EntryPoint, StateKey.TargetPlatforms, out var platforms)
             && platforms.HasFlag(TargetPlatform.WebAssembly);
 
         public override TargetPlatform GetApplicableTargets(Manifest.Manifest manifest) =>
@@ -21,6 +20,12 @@ namespace DotNetCheck.Checkups
 
         public override async Task<DiagnosticResult> Examine(SharedState history)
         {
+            if (Util.CI || Util.NonInteractive)
+            {
+                ReportStatus("Skipping in CI / non-interactive mode", Status.Ok);
+                return DiagnosticResult.Ok(this);
+            }
+            
             var check = await Util.ShellCommand(
                 "dotnet",
                 Directory.GetCurrentDirectory(),

--- a/UnoCheck/Checkups/HttpsDevCertCheckup.cs
+++ b/UnoCheck/Checkups/HttpsDevCertCheckup.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using System.Threading.Tasks;
+using DotNetCheck.Models;
+using DotNetCheck.Solutions;
+
+namespace DotNetCheck.Checkups
+{
+    public class HttpsDevCertCheckup : Checkup
+    {
+        public override string Id => "https-dev-cert";
+        public override string Title => "HTTPS Developer Certificate Trust";
+
+        // Only examine when WebAssembly is one of the targets
+        public override bool ShouldExamine(SharedState history) =>
+            history.TryGetState<TargetPlatform>(StateKey.EntryPoint, StateKey.TargetPlatforms, out var platforms)
+            && platforms.HasFlag(TargetPlatform.WebAssembly);
+
+        public override TargetPlatform GetApplicableTargets(Manifest.Manifest manifest) =>
+            TargetPlatform.WebAssembly;
+
+        public override async Task<DiagnosticResult> Examine(SharedState history)
+        {
+            var check = await Util.ShellCommand(
+                "dotnet",
+                Directory.GetCurrentDirectory(),
+                Util.Verbose,
+                ["dev-certs", "https", "-c", "-t"]);
+
+            if (check.ExitCode == 0)
+            {
+                ReportStatus("Developer HTTPS certificates are trusted", Status.Ok);
+                return DiagnosticResult.Ok(this);
+            }
+
+            ReportStatus("Developer HTTPS certificates are not trusted", Status.Error);
+
+            var suggestion = new Suggestion(
+                "Trust HTTPS developer certificates",
+                "This command will trust your local dev certs so that HTTPS works correctly in WebAssembly apps.",
+                new ActionSolution(async (_, _) =>
+                {
+                    await Util.ShellCommand(
+                        "dotnet",
+                        Directory.GetCurrentDirectory(),
+                        Util.Verbose,
+                        ["dev-certs", "https", "--trust"]);
+                })
+            );
+
+            return new DiagnosticResult(Status.Error, this, suggestion);
+        }
+    }
+}

--- a/UnoCheck/Checkups/HttpsDevCertCheckup.cs
+++ b/UnoCheck/Checkups/HttpsDevCertCheckup.cs
@@ -11,8 +11,9 @@ namespace DotNetCheck.Checkups
         public override string Title => "HTTPS Developer Certificate Trust";
 
         // Only examine when WebAssembly is one of the targets
-        public override bool ShouldExamine(SharedState history) =>
-            history.TryGetState<TargetPlatform>(StateKey.EntryPoint, StateKey.TargetPlatforms, out var platforms)
+        public override bool ShouldExamine(SharedState history) => 
+            !Util.CI && !Util.NonInteractive
+            && history.TryGetState<TargetPlatform>(StateKey.EntryPoint, StateKey.TargetPlatforms, out var platforms)
             && platforms.HasFlag(TargetPlatform.WebAssembly);
 
         public override TargetPlatform GetApplicableTargets(Manifest.Manifest manifest) =>

--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -27,6 +27,7 @@ namespace DotNetCheck
 				new AndroidEmulatorCheckup(),
 				new VisualStudioWindowsCheckup(),
 				new VSWinWorkloadsCheckup(),
+				new HttpsDevCertCheckup(),
 				new AndroidSdkPackagesCheckup(),
 				new XCodeCheckup(),
 				new DotNetCheckup()

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -55,6 +55,7 @@ namespace DotNetCheck
 		public static bool Verbose { get; set; }
 		public static string LogFile { get; set; }
 		public static bool CI { get; set; }
+		public static bool NonInteractive { get; set; }
 
 		public static Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
 


### PR DESCRIPTION
This checkup is available if one of the targets is WASM.
![image](https://github.com/user-attachments/assets/f738f424-69a4-4a21-bb27-8b711c6f6886)
It runs `dev-certs https -c -t` to check for trusted certs and `dev-certs https --trust` to fix.
Fixes #375 