### PR TITLE
fix: Ensure uno-check window appears on-top

### DIFF
--- a/UnoCheck/ConsoleWindowHelper.cs
+++ b/UnoCheck/ConsoleWindowHelper.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DotNetCheck;
+
+internal static class ConsoleWindowHelpers
+{
+    private const int SWP_NOSIZE = 0x0001;
+    private const int SWP_NOMOVE = 0x0002;
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+
+    public static void BringToFront()
+    {
+        var hWnd = GetConsoleWindow();
+        if (hWnd == IntPtr.Zero)
+            return;
+
+        // make the window top-most
+        SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+
+        // give it the keyboard focus
+        SetForegroundWindow(hWnd);
+    }
+
+    // https://learn.microsoft.com/en-us/windows/console/getconsolewindow
+    [DllImport("kernel32.dll")] private static extern IntPtr GetConsoleWindow();
+    
+    // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow
+    [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
+    
+    // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowpos
+    [DllImport("user32.dll")] private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+}

--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -16,8 +16,10 @@ namespace DotNetCheck
 		{
 			TelemetryClient.Init();
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
 				ConsoleWindowHelpers.BringToFront();
-			
+			}
+
 			// Need to register the code pages provider for code that parses
 			// and later needs ISO-8859-2
 			System.Text.Encoding.RegisterProvider(

--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using DotNetCheck.Checkups;
 using DotNetCheck.Cli;
@@ -14,7 +15,9 @@ namespace DotNetCheck
 		static Task<int> Main(string[] args)
 		{
 			TelemetryClient.Init();
-
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				ConsoleWindowHelpers.BringToFront();
+			
 			// Need to register the code pages provider for code that parses
 			// and later needs ISO-8859-2
 			System.Text.Encoding.RegisterProvider(


### PR DESCRIPTION
I can't repro that issue on my machine, i guess it might be specific to some Windows version. But this might fix the issue. Requires testing
Fixes https://github.com/unoplatform/uno.studio/issues/782