### PR TITLE
fix: "No such command" when typing uno-check check

### DIFF
--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -74,7 +74,9 @@ namespace DotNetCheck
 
 			var firstArg = args?.FirstOrDefault()?.Trim()?.ToLowerInvariant() ?? string.Empty;
 			var isGlobalOption = firstArg is "-h" or "--help" or "-v" or "--version";
-			if (!isGlobalOption && firstArg != "list" && firstArg != "config" && firstArg != "acquirepackages")
+			var isExplicitCommand = firstArg is "check" or "list" or "config";
+
+			if (!isGlobalOption && !isExplicitCommand)
 				finalArgs.Add("check");
 
 			if (args?.Any() ?? false)


### PR DESCRIPTION
More info - https://github.com/unoplatform/uno.check/issues/340#issuecomment-2849118302
Also removes the mentioning of "acquirepackages" since i don't think it exists anymore as a command.
Thanks @DevTKSS for finding that! Could you give it a test?
