### PR TITLE
Version bump after 1.31 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.31-dev.{height}",
+  "version": "1.32-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION

This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/1.31, based on #387