### PR TITLE
fix(manifests): older net 9 version on preview manifest than on the regular manifest

### DIFF
--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -3,7 +3,7 @@
     "toolVersion": "1.14.0",
     "variables": {
       "OPENJDK_VERSION": "11.0.20.1",
-      "DOTNET_SDK_VERSION": "9.0.203",
+      "DOTNET_SDK_VERSION": "9.0.300",
       "MACCATALYST_SDK_VERSION": "18.4.9288/9.0.100",
       "IOS_SDK_VERSION": "18.4.9288/9.0.100",
       "TVOS_SDK_VERSION": "18.4.9288/9.0.100",


### PR DESCRIPTION
Fixes #413 

this could potentially lead to a wrong behaviour if someone actually uses the -pre or -d flags