### PR TITLE
fix: launchSettings.json and add regression test

### DIFF
--- a/UnoCheck.Tests/LaunchSettingsTests.cs
+++ b/UnoCheck.Tests/LaunchSettingsTests.cs
@@ -5,7 +5,7 @@ namespace UnoCheck.Tests;
 public class LaunchSettingsTests
 {
     [Fact]
-    public void LaunchProfile_Run_ShowsVersion()
+    public void Ensure_LaunchSettings_File_Is_Valid()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var launchSettings = Path.Combine(repoRoot, "UnoCheck", "Properties", "launchSettings.json");
@@ -13,7 +13,7 @@ public class LaunchSettingsTests
 
         var projectPath = Path.Combine(repoRoot, "UnoCheck", "UnoCheck.csproj");
 
-        var psi = new ProcessStartInfo("dotnet", $"run --no-build --project \"{projectPath}\" --framework net6.0 --launch-profile UnoCheck -- --non-interactive --ci")
+        var psi = new ProcessStartInfo("dotnet", $"run --project \"{projectPath}\" --framework net6.0 --launch-profile UnoCheck -- --non-interactive --ci")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/UnoCheck.Tests/LaunchSettingsTests.cs
+++ b/UnoCheck.Tests/LaunchSettingsTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics;
+
+namespace UnoCheck.Tests;
+
+public class LaunchSettingsTests
+{
+    [Fact]
+    public void LaunchProfile_Run_ShowsVersion()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var launchSettings = Path.Combine(repoRoot, "UnoCheck", "Properties", "launchSettings.json");
+        Assert.True(File.Exists(launchSettings));
+
+        var projectPath = Path.Combine(repoRoot, "UnoCheck", "UnoCheck.csproj");
+
+        var psi = new ProcessStartInfo("dotnet", $"run --no-build --project \"{projectPath}\" --framework net6.0 --launch-profile UnoCheck -- --non-interactive --ci")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = repoRoot
+        };
+
+        using var process = Process.Start(psi)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(string.IsNullOrEmpty(error), error);
+        Assert.DoesNotContain("Error: Could not find a part of the path", output);
+    }
+}

--- a/UnoCheck/Properties/launchSettings.json
+++ b/UnoCheck/Properties/launchSettings.json
@@ -2,7 +2,8 @@
   "profiles": {
     "UnoCheck": {
       "commandName": "Project",
-      "commandLineArgs": "--verbose --manifest ..\\..\\..\\..\\manifests\\uno.ui.manifest.json"
+      "commandLineArgs": "--verbose --manifest manifests/uno.ui.manifest.json",
+      "workingDirectory": ".."
     },
     "WSL 2": {
       "commandName": "WSL2",


### PR DESCRIPTION
This PR fixes the launchsettings.json once more, without that PR i can't run the uno.check. Also adding some regression test for launchsettings.json verifying that it's valid