### PR TITLE
chore: skip HttpsDevCertCheckup for Linux

### DIFF
--- a/UnoCheck/Checkups/HttpsDevCertCheckup.cs
+++ b/UnoCheck/Checkups/HttpsDevCertCheckup.cs
@@ -9,7 +9,8 @@ namespace DotNetCheck.Checkups
     {
         public override string Id => "https-dev-cert";
         public override string Title => "HTTPS Developer Certificate Trust";
-
+        public override bool IsPlatformSupported(Platform platform) => platform != Platform.Linux;
+        
         // Only examine when WebAssembly is one of the targets
         public override bool ShouldExamine(SharedState history) => 
             history.TryGetState<TargetPlatform>(StateKey.EntryPoint, StateKey.TargetPlatforms, out var platforms)


### PR DESCRIPTION
Currently HttpsDevCertCheckup will fail in the majority of cases. `dotnet dev-certs` requires libnss3-tools, setting up SSL_CERT_DIR environment variable. I am thinking that if dotnet doesen't do that by default we probably shouldn't also. Proposing to skip the check since we can't guaratee that it will 100% fix the issue on the user's PC.

Fixes https://github.com/unoplatform/private/issues/907