### PR TITLE
fix: Adjust emulator setup link in AndroidEmulatorCheckup to use a proper AKA Link

### DIFF
--- a/UnoCheck/Checkups/AndroidEmulatorCheckup.cs
+++ b/UnoCheck/Checkups/AndroidEmulatorCheckup.cs
@@ -15,7 +15,7 @@ namespace DotNetCheck.Checkups
 	public class AndroidEmulatorCheckup : Checkup
 	{
 		private const string ArmArch = "arm64-v8a";
-		private const string UnableToFindEmulatorsMessage = "Unable to find any Android Emulators.  See the Uno documentation for emulator setup: [underline]https://platform.uno/docs/articles/common-issues-mobile-debugging.html#android-emulator-setup[/]";
+		private const string UnableToFindEmulatorsMessage = "Unable to find any Android emulators. See the Uno documentation for setup instructions: [underline]https://aka.platform.uno/emulators-troubleshooting-android[/]";
 		public override IEnumerable<CheckupDependency> DeclareDependencies(IEnumerable<string> checkupIds)
 			=> new [] { new CheckupDependency("androidsdk") };
 
@@ -133,7 +133,7 @@ namespace DotNetCheck.Checkups
 
 								var sdkPackage = installedPackages.FirstOrDefault(p =>
 								{
-									// This will be false if the proccess runs on Rosetta emulation
+									// This will be false if the process runs on Rosetta emulation
 									// and will install the wrong emulator (x86_64)
 									// https://github.com/dotnet/runtime/issues/42130
 									return Util.IsArm64


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno.check/issues/429

## PR Type:
Copy the labels that apply to this PR and paste them above:

- Aka link usage


## Description

Adjust emulator setup link in AndroidEmulatorCheckup to use a proper AKA Link

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes
