### PR TITLE
ci: Fix publish_prod job to load local tag-release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,11 +501,18 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: windows-latest
     environment: Production
-
     needs:
       - sign
-
+  
+    permissions:
+      contents: write  # allow pushing tags
+  
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+  
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -517,5 +524,5 @@ jobs:
         run: |
           dotnet nuget push artifacts\*.nupkg -s https://api.nuget.org/v3/index.json -k "${{ secrets.NUGET_ORG_API_KEY }}"
 
-      - name: "Tag Release"
-        uses: ./.github/actions/tag-release
+      - name: Tag Release
+        uses: ./.github/workflows/actions/tag-release


### PR DESCRIPTION
## PR Type:

- 🏗️ Build or CI related changes

## What is the current behavior? 🤔

The `publish_prod` job fails after publishing to NuGet because the local `tag-release` action cannot be found.  
This happens because:
- The workflow referenced `.github/actions/tag-release`, but the action actually lives in `.github/workflows/actions/tag-release`.
- The job didn’t include a `checkout` step before using the local action.
- GitHub token permissions for pushing tags were not explicitly enabled.

## What is the new behavior? 🚀

- Corrected the path to the `tag-release` action.  
- Added a `checkout` step so the local action is available on disk.  
- Granted `contents: write` permission in the job to allow pushing tags.  

With these changes, the production publish workflow will successfully push the NuGet package **and** tag the release.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
