### PR TITLE
docs(uno-check): Fix incorrect example for --pre-major flag

### DIFF
--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -121,7 +121,7 @@ This generally uses the preview builds of the next major version of .NET availab
 The manifest is hosted by default here: [uno.ui-preview-major.manifest.json](https://raw.githubusercontent.com/unoplatform/uno.check/main/manifests/uno.ui-preview-major.manifest.json)
 
 ```bash
-uno-check --pre
+uno-check --pre-major
 ```
 
 ### `--ci` Continuous Integration
@@ -164,3 +164,4 @@ Example:
 ```bash
 uno-check config --dev --nuget-sources --dotnet-version --dotnet-pre true
 ```
+


### PR DESCRIPTION
## PR Type:

- 📚 Documentation content changes

## What is the current behavior? 🤔

The documentation for `uno-check` incorrectly shows the example for the `--pre-major` flag as:

`uno-check --pre`

## What is the new behavior? 🚀

The example is corrected to:

`uno-check --pre-major`

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
