### PR TITLE
Fix: Resolve stdin/stdout I/O errors on macOS/Linux after tool update and relaunch

### DIFF
--- a/UnoCheck/ToolUpdater.cs
+++ b/UnoCheck/ToolUpdater.cs
@@ -127,7 +127,18 @@ internal static class ToolUpdater
                 exec {ToolInfo.ToolCommand} {argsForRelaunch}
                 """;
 
-            File.WriteAllText(tempScript, scriptContent);
+            try
+            {
+                File.WriteAllText(tempScript, scriptContent);
+            }
+            catch (Exception ex)
+            {
+                Util.Exception(ex);
+                AnsiConsole.MarkupLine($"[bold red]{Icon.Error} Failed to execute update script. Please update manually and relaunch.[/]");
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"dotnet tool update --global {ToolInfo.ToolPackageId} --version {version}");
+                Environment.Exit(1);                
+            }
             
             // Make script executable
             Process.Start(new ProcessStartInfo("chmod", $"+x \"{tempScript}\"")


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

When users selected the "Update" option on macOS/Linux, the tool would update and relaunch, but the relaunched process lost its connection to the terminal's stdin. This caused interactive CLI prompts to fail with errors like:

"zsh: command not found: n"
["Error Input/Output error"](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Users were unable to respond to prompts such as "Attempt to fix? [y/n]" after the relaunch.


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

Implemented atomic process replacement on Unix systems using the execv() system call via P/Invoke. A temporary shell script performs the update and relaunch sequence, with execv() replacing the current process to preserve the terminal session and file descriptors (stdin/stdout/stderr). This ensures interactive CLI prompts function correctly after the tool updates itself.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->