### PR TITLE
fix: harden CI manifest validation and main fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,12 @@ jobs:
            manifest_name: Test net9.0-browserwasm TFM
            tool_params: '--tfm net9.0-browserwasm'
          - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test default Uno template TFMs with net10
+           tool_params: '--tfm net10.0-android --tfm net10.0-ios --tfm net10.0-maccatalyst --tfm net10.0-windows10.0.19041 --tfm net10.0-browserwasm --tfm net10.0-desktop'
+         - manifest: 'manifests\uno.ui.manifest.json'
+           manifest_name: Test net10.0-browserwasm TFM
+           tool_params: '--tfm net10.0-browserwasm'
+         - manifest: 'manifests\uno.ui.manifest.json'
            manifest_name: Test unoSdkVersion
            tool_params: '--unoSdkVersion 5.6.19'
 
@@ -251,6 +257,18 @@ jobs:
            tool_params: '--tfm net8.0-browserwasm'
 
          - manifest: 'manifests/uno.ui.manifest.json'
+           manifest_name: Test default Uno template TFMs with net10
+           os: macos-14
+           dotnet_version: 8.0.300
+           tool_params: '--tfm net10.0-android --tfm net10.0-ios --tfm net10.0-maccatalyst --tfm net10.0-windows10.0.19041 --tfm net10.0-browserwasm --tfm net10.0-desktop'
+
+         - manifest: 'manifests/uno.ui.manifest.json'
+           manifest_name: Test net10.0-browserwasm TFM
+           os: macos-14
+           dotnet_version: 8.0.300
+           tool_params: '--tfm net10.0-browserwasm'
+
+         - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Stable
            os: macos-15
            dotnet_version: 8.0.300
@@ -352,6 +370,12 @@ jobs:
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net9.0-browserwasm TFM
            tool_params: '--tfm net9.0-browserwasm'
+         - manifest: 'manifests/uno.ui.manifest.json'
+           manifest_name: Test default Uno template TFMs with net10
+           tool_params: '--tfm net10.0-android --tfm net10.0-ios --tfm net10.0-maccatalyst --tfm net10.0-windows10.0.19041 --tfm net10.0-browserwasm --tfm net10.0-desktop'
+         - manifest: 'manifests/uno.ui.manifest.json'
+           manifest_name: Test net10.0-browserwasm TFM
+           tool_params: '--tfm net10.0-browserwasm'
          - manifest: 'manifests/uno.ui.manifest.json'
            manifest_name: Test net9.0-tvos TFM
            tool_params: '--tfm net9.0-tvos'

--- a/UnoCheck.Tests/ManifestVersionGuardTests.cs
+++ b/UnoCheck.Tests/ManifestVersionGuardTests.cs
@@ -1,0 +1,52 @@
+using DotNetCheck.Manifest;
+using NuGet.Versioning;
+
+namespace UnoCheck.Tests;
+
+public class ManifestVersionGuardTests
+{
+    public static IEnumerable<object[]> EmbeddedManifestResourceNames =>
+    [
+        [Manifest.DefaultManifestResourceName],
+        [Manifest.PreviewManifestResourceName],
+        [Manifest.PreviewMajorManifestResourceName]
+    ];
+
+    [Theory]
+    [MemberData(nameof(EmbeddedManifestResourceNames))]
+    public async Task EmbeddedManifest_HasValidDotNetAndWasmToolsVersionFormats(string manifestResourceName)
+    {
+        var manifest = await Manifest.FromEmbeddedResource(manifestResourceName);
+
+        Assert.NotNull(manifest?.Check?.Variables);
+        Assert.True(manifest.Check.Variables.TryGetValue("DOTNET_SDK_VERSION", out var dotnetSdkVersion));
+        var sdkVersion = dotnetSdkVersion?.ToString();
+        Assert.NotNull(sdkVersion);
+        Assert.True(NuGetVersion.TryParse(sdkVersion, out _));
+
+        Assert.True(manifest.Check.Variables.TryGetValue("WASMTOOLS_VERSION", out var wasmToolsVersion));
+        var wasmVersion = wasmToolsVersion?.ToString();
+        Assert.NotNull(wasmVersion);
+
+        var wasmVersionParts = wasmVersion!.Split('/');
+        Assert.Equal(2, wasmVersionParts.Length);
+        Assert.True(NuGetVersion.TryParse(wasmVersionParts[0], out _));
+        Assert.True(NuGetVersion.TryParse(wasmVersionParts[1], out _));
+    }
+
+    [Theory]
+    [MemberData(nameof(EmbeddedManifestResourceNames))]
+    public async Task EmbeddedManifest_DefinesWasmToolsWorkloadForWebAssembly(string manifestResourceName)
+    {
+        var manifest = await Manifest.FromEmbeddedResource(manifestResourceName);
+        var workloads = manifest?.Check?.DotNet?.Sdks?.SelectMany(sdk => sdk.Workloads ?? [])?.ToArray();
+
+        Assert.NotNull(workloads);
+        Assert.True(manifest!.Check.Variables.TryGetValue("WASMTOOLS_VERSION", out var expectedWasmToolsVersion));
+
+        Assert.Contains(workloads!, workload =>
+            workload.Id == "wasm-tools"
+            && workload.WorkloadManifestId == "microsoft.net.workload.mono.toolchain.current"
+            && workload.Version == expectedWasmToolsVersion?.ToString());
+    }
+}

--- a/UnoCheck.Tests/ToolInfoTests.cs
+++ b/UnoCheck.Tests/ToolInfoTests.cs
@@ -1,4 +1,5 @@
 using DotNetCheck;
+using DotNetCheck.Manifest;
 
 namespace UnoCheck.Tests;
 
@@ -41,10 +42,10 @@ public class ToolInfoTests
     }
 
     [Fact]
-    public async Task LoadManifest_LoadsMainManifest_WhenMainChannelRequested()
+    public async Task LoadManifest_MainChannel_FallsBackToEmbeddedManifest_WhenMainUrlIsEmpty()
     {
         // Act
-        var manifest = await ToolInfo.LoadManifest(null, ManifestChannel.Main);
+        var manifest = await ToolInfo.LoadManifest(null, ManifestChannel.Main, string.Empty);
         
         // Assert
         Assert.NotNull(manifest);
@@ -52,11 +53,20 @@ public class ToolInfoTests
         Assert.NotNull(manifest.Check.ToolVersion);
     }
 
+    [Fact]
+    public async Task LoadManifest_MainChannel_FallsBackToEmbeddedManifest_WhenRemoteLoadFails()
+    {
+        var manifest = await ToolInfo.LoadManifest(null, ManifestChannel.Main, "not a valid url");
+
+        Assert.NotNull(manifest);
+        Assert.NotNull(manifest.Check);
+        Assert.NotEmpty(manifest.Check.ToolVersion);
+    }
+
     [Theory]
     [InlineData(ManifestChannel.Default)]
     [InlineData(ManifestChannel.Preview)]
     [InlineData(ManifestChannel.PreviewMajor)]
-    [InlineData(ManifestChannel.Main)]
     public async Task LoadManifest_LoadsValidManifest_ForAllChannels(ManifestChannel channel)
     {
         // Act
@@ -67,5 +77,37 @@ public class ToolInfoTests
         Assert.NotNull(manifest.Check);
         Assert.NotEmpty(manifest.Check.ToolVersion);
         Assert.NotNull(manifest.Check.Variables);
+    }
+
+    [Fact]
+    public void Validate_MissingToolVersion_NonStrict_ReturnsTrue()
+    {
+        var manifest = new Manifest
+        {
+            Check = new Check
+            {
+                ToolVersion = null
+            }
+        };
+
+        var result = ToolInfo.Validate(manifest, strictManifest: false);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Validate_MissingToolVersion_Strict_ReturnsFalse()
+    {
+        var manifest = new Manifest
+        {
+            Check = new Check
+            {
+                ToolVersion = null
+            }
+        };
+
+        var result = ToolInfo.Validate(manifest, strictManifest: true);
+
+        Assert.False(result);
     }
 }

--- a/UnoCheck.Tests/ToolInfoValidationTests.cs
+++ b/UnoCheck.Tests/ToolInfoValidationTests.cs
@@ -1,0 +1,116 @@
+using DotNetCheck;
+using DotNetCheck.Manifest;
+
+namespace UnoCheck.Tests;
+
+public class ToolInfoValidationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("not-a-version")]
+    [InlineData("9999.0.0")]
+    public void Validate_WhenToolVersionGateWarnsInNonStrictMode_StillFailsOnIncompatibleSdk(string? toolVersion)
+    {
+        var manifest = new Manifest
+        {
+            Check = new Check
+            {
+                ToolVersion = toolVersion,
+                DotNet = new DotNet
+                {
+                    Sdks =
+                    [
+                        new DotNetSdk
+                        {
+                            Version = DotNetSdk.Version6Preview6.ToNormalizedString()
+                        }
+                    ]
+                }
+            }
+        };
+
+        var result = ToolInfo.Validate(manifest, strictManifest: false);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Validate_WhenManifestRequiredVersionIsHigherThanCurrent_AllowsNonStrictMode()
+    {
+        var manifest = new Manifest
+        {
+            Check = new Check
+            {
+                ToolVersion = "9999.0.0"
+            }
+        };
+
+        var result = ToolInfo.Validate(manifest, strictManifest: false);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Validate_WhenManifestRequiredVersionIsHigherThanCurrent_FailsStrictMode()
+    {
+        var manifest = new Manifest
+        {
+            Check = new Check
+            {
+                ToolVersion = "9999.0.0"
+            }
+        };
+
+        var result = ToolInfo.Validate(manifest, strictManifest: true);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Validate_WhenToolVersionMatches_PassesStrictMode()
+    {
+        var manifest = new Manifest
+        {
+            Check = new Check
+            {
+                ToolVersion = ToolInfo.CurrentVersion.ToString()
+            }
+        };
+
+        var result = ToolInfo.Validate(manifest, strictManifest: true);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Validate_WhenToolVersionFormatIsInvalid_AllowsNonStrictMode()
+    {
+        var manifest = new Manifest
+        {
+            Check = new Check
+            {
+                ToolVersion = "not-a-version"
+            }
+        };
+
+        var result = ToolInfo.Validate(manifest, strictManifest: false);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Validate_WhenToolVersionFormatIsInvalid_FailsStrictMode()
+    {
+        var manifest = new Manifest
+        {
+            Check = new Check
+            {
+                ToolVersion = "not-a-version"
+            }
+        };
+
+        var result = ToolInfo.Validate(manifest, strictManifest: true);
+
+        Assert.False(result);
+    }
+}

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -104,7 +104,9 @@ namespace DotNetCheck.Cli
 
 			var manifest = await ToolInfo.LoadManifest(settings.Manifest, channel);
 
-			if (!ToolInfo.Validate(manifest))
+			var strictManifest = settings.CI;
+
+			if (!ToolInfo.Validate(manifest, strictManifest))
 			{
 				ToolInfo.ExitPrompt(settings.NonInteractive);
 				return -1;

--- a/UnoCheck/CheckSettings.cs
+++ b/UnoCheck/CheckSettings.cs
@@ -24,7 +24,7 @@ namespace DotNetCheck
         [CommandOption("--pre-major|--preview-major")]
         public bool PreviewMajor { get; set; }
 
-        [CommandOption("--main")]
+		[CommandOption("--dev-manifest|--main")]
 		public bool Main { get; set; }
 
 		[CommandOption("--dotnet <SDK_ROOT>")]

--- a/UnoCheck/ConfigSettings.cs
+++ b/UnoCheck/ConfigSettings.cs
@@ -14,7 +14,7 @@ namespace DotNetCheck
         [CommandOption("--pre-major|--preview-major")]
         public bool PreviewMajor { get; set; }
 
-        [CommandOption("--main")]
+		[CommandOption("--dev-manifest|--main")]
 		public bool Main { get; set; }
 
 		[CommandOption("-n|--non-interactive")]

--- a/UnoCheck/ListCheckupSettings.cs
+++ b/UnoCheck/ListCheckupSettings.cs
@@ -13,7 +13,7 @@ namespace DotNetCheck
         [CommandOption("--pre-major|--preview-major")]
         public bool PreviewMajor { get; set; }
 
-        [CommandOption("--main")]
+		[CommandOption("--dev-manifest|--main")]
 		public bool Main { get; set; }
 
 		[CommandOption("-n|--non-interactive")]

--- a/UnoCheck/ToolInfo.cs
+++ b/UnoCheck/ToolInfo.cs
@@ -1,4 +1,5 @@
-﻿using DotNetCheck.DotNet;
+﻿#nullable enable
+using DotNetCheck.DotNet;
 using NuGet.Common;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -27,14 +28,42 @@ namespace DotNetCheck
 		public const string ToolName = "Uno Platform Check";
 		public const string ToolPackageId = "Uno.Check";
 		public const string ToolCommand = "uno-check";
+		internal const string MainManifestUrl = "https://raw.githubusercontent.com/unoplatform/uno.check/main/manifests/uno.ui.manifest.json";
 
-		public static async Task<Manifest.Manifest> LoadManifest(string fileOrUrl, ManifestChannel channel)
+		public static Task<Manifest.Manifest> LoadManifest(string? fileOrUrl, ManifestChannel channel)
+			=> LoadManifest(fileOrUrl, channel, mainManifestUrlOverride: null);
+
+		internal static async Task<Manifest.Manifest> LoadManifest(string? fileOrUrl, ManifestChannel channel, string? mainManifestUrlOverride)
 		{
 			// If a specific file or URL is provided, use it
 			if (!string.IsNullOrEmpty(fileOrUrl))
 			{
 				Util.Log($"Loading Manifest from: {fileOrUrl}");
 				return await Manifest.Manifest.FromFileOrUrl(fileOrUrl);
+			}
+
+			if (channel == ManifestChannel.Main)
+			{
+				var mainManifestUrl = mainManifestUrlOverride is null ? MainManifestUrl : mainManifestUrlOverride;
+
+				if (!string.IsNullOrWhiteSpace(mainManifestUrl))
+				{
+					try
+					{
+						Util.Log($"Loading Main Manifest from URL: {mainManifestUrl}");
+						return await Manifest.Manifest.FromFileOrUrl(mainManifestUrl);
+					}
+					catch (Exception ex)
+					{
+						Util.Log($"Failed loading Main Manifest from URL: {mainManifestUrl}. Falling back to embedded stable manifest.");
+						Util.Exception(ex);
+						AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Could not load main manifest from configured source. Falling back to embedded stable manifest.[/]");
+					}
+				}
+				else
+				{
+					Util.Log("Main Manifest URL is not configured. Falling back to embedded stable manifest.");
+				}
 			}
 
 			// Otherwise, load from embedded resources based on the channel
@@ -55,30 +84,60 @@ namespace DotNetCheck
 		public static NuGetVersion CurrentVersion
 			=> NuGetVersion.Parse(FileVersionInfo.GetVersionInfo(typeof(ToolInfo).Assembly.Location).FileVersion);
 
-		public static bool Validate(Manifest.Manifest manifest)
+		public static bool Validate(Manifest.Manifest manifest, bool strictManifest = false)
 		{
-			var toolVersion = manifest?.Check?.ToolVersion ?? "0.1.0";
+			var toolVersion = manifest?.Check?.ToolVersion;
 
 			Util.Log($"Required Version: {toolVersion}");
 
-			var fileVersion = NuGetVersion.Parse(FileVersionInfo.GetVersionInfo(typeof(ToolInfo).Assembly.Location).FileVersion);
+			var fileVersion = CurrentVersion;
 
 			Util.Log($"Current Version: {fileVersion}");
 
-			if (string.IsNullOrEmpty(toolVersion) || !NuGetVersion.TryParse(toolVersion, out var toolVer) || fileVersion < toolVer)
+			if (string.IsNullOrWhiteSpace(toolVersion))
 			{
-				return true;
-				// Console.WriteLine();
-				// AnsiConsole.MarkupLine($"[bold red]{Icon.Error} Updating to version {toolVersion} or newer is required:[/]");
-				// AnsiConsole.MarkupLine($"[blue]  dotnet tool update --global {ToolPackageId}[/]");
+				AnsiConsole.WriteLine();
+				AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Uno.Check manifest version check failed.[/]");
+				AnsiConsole.MarkupLine("[yellow]The manifest does not define a required Uno.Check tool version (check.toolVersion).[/]");
+				AnsiConsole.MarkupLine("[yellow]Consider using a known-good manifest via the --manifest option, switching to the stable manifest channel, or asking the manifest maintainer to define a valid semantic version for check.toolVersion.[/]");
 
-				// if (Debugger.IsAttached)
-				// {
-				// 	if (AnsiConsole.Confirm("Mismatched version, continue debugging anyway?"))
-				// 		return true;
-				// }
+				if (strictManifest)
+				{
+					AnsiConsole.MarkupLine($"[bold red]{Icon.Error} Strict manifest mode is enabled (CI). Aborting.[/]");
+					return false;
+				}
 
-				// return false;
+				AnsiConsole.MarkupLine("[yellow]Continuing in non-strict mode. Results may be unreliable until the manifest is corrected.[/]");
+			}
+			else if (!NuGetVersion.TryParse(toolVersion, out var toolVer))
+			{
+				AnsiConsole.WriteLine();
+				AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Uno.Check manifest version check failed.[/]");
+				AnsiConsole.MarkupLine($"[yellow]The manifest requires an invalid Uno.Check version format: {Markup.Escape(toolVersion!)}[/]");
+				AnsiConsole.MarkupLine("[yellow]Please fix the manifest 'check.toolVersion' value to a valid semantic version.[/]");
+
+				if (strictManifest)
+				{
+					AnsiConsole.MarkupLine($"[bold red]{Icon.Error} Strict manifest mode is enabled (CI). Aborting.[/]");
+					return false;
+				}
+
+				AnsiConsole.MarkupLine("[yellow]Continuing in non-strict mode. Results may be unreliable until the manifest is corrected.[/]");
+			}
+			else if (fileVersion < toolVer)
+			{
+				AnsiConsole.WriteLine();
+				AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Uno.Check version support mismatch detected.[/]");
+				AnsiConsole.MarkupLine($"[yellow]Required by manifest: {Markup.Escape(toolVersion!)} | Current: {fileVersion}[/]");
+				AnsiConsole.MarkupLine($"[blue]Update command: dotnet tool update --global {ToolPackageId}[/]");
+
+				if (strictManifest)
+				{
+					AnsiConsole.MarkupLine($"[bold red]{Icon.Error} Strict manifest mode is enabled (CI). Aborting.[/]");
+					return false;
+				}
+
+				AnsiConsole.MarkupLine($"[yellow]Continuing in non-strict mode. Results may be unreliable until Uno.Check is updated.[/]");
 			}
 
 			var minSupportedDotNetSdkVersion = Manifest.DotNetSdk.Version6Preview7;
@@ -87,7 +146,7 @@ namespace DotNetCheck
 			if (manifest?.Check?.DotNet?.Sdks?.Any(dnsdk =>
 				NuGetVersion.TryParse(dnsdk.Version, out var dnsdkVersion) && dnsdkVersion < minSupportedDotNetSdkVersion) ?? false)
 			{
-				Console.WriteLine();
+				AnsiConsole.WriteLine();
 				AnsiConsole.MarkupLine($"[bold red]{Icon.Error} This version of the tool is incompatible with installing an older version of .NET 6[/]");
 				return false;
 			}

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -124,9 +124,30 @@ The manifest is hosted by default here: [uno.ui-preview-major.manifest.json](htt
 uno-check --pre-major
 ```
 
+### `--dev-manifest` (alias: `--main`) Development manifest channel
+
+This uses the latest manifest from the `main` branch of the
+`uno.check` repository.
+
+The manifest is hosted by default here:
+[uno.ui.manifest.json](https://raw.githubusercontent.com/unoplatform/uno.check/main/manifests/uno.ui.manifest.json)
+
+If the remote manifest cannot be loaded (for example due to network
+restrictions), `uno-check` falls back to the embedded stable manifest and prints a warning.
+
+```bash
+uno-check --dev-manifest
+```
+
 ### `--ci` Continuous Integration
 
 Uses the dotnet-install powershell / bash scripts for installing the dotnet SDK version from the manifest instead of the global installer.
+
+In CI mode, manifest/tool support validation runs in strict mode. In this mode,
+the command fails fast if the manifest omits `check.toolVersion`, if
+`check.toolVersion` has an invalid format, or if the current `uno-check`
+version is older than the manifest minimum tool version, and prints an explicit
+error or update message.
 
 ```bash
 uno-check --ci

--- a/doc/troubleshooting-uno-check.md
+++ b/doc/troubleshooting-uno-check.md
@@ -27,5 +27,13 @@ If you run into problems with uno-check, you should generally try the following:
 1. Run with `uno-check --force-dotnet` to ensure the workload repair/update/install commands run regardless of if uno-check thinks the workload versions look good.
 1. If you encounter the error `Unable to load the service index` when installing `uno-check` for a host name not ending by `nuget.org`, try using the `--ignore-failed-sources` parameter.
 1. If you still have errors, it may help to run the [Clean-Old-DotNet6-Previews.ps1](https://github.com/unoplatform/uno.check/blob/main/Clean-Old-DotNet6-Previews.ps1) script to remove old SDK Packs, templates, or otherwise old cached preview files that might be causing the problem.  Try running `uno-check --force-dotnet` again after this step.
+1. If you encounter a message similar to `Uno.Check version support mismatch detected` and you are running with `--ci`, update the tool first:
+
+    ```dotnetcli
+    dotnet tool update -g uno.check --add-source https://api.nuget.org/v3/index.json
+    ```
+
+    Then rerun `uno-check`.
+
 1. If you encounter the message `There were one or more problems detected. Please review the errors and correct them and run uno-check again.`, but if you have done all the previously mentioned steps, try running it with `--verbose` flag to see where it is failing.
 1. Finally, if you have other problems, run also with `--verbose` flag and capture the output and add it to a new issue.


### PR DESCRIPTION
## Summary
This PR hardens manifest compatibility handling for .NET versions sanity checks by making validation strict in CI and by making `--dev-manifest` / `--main` fallback behavior explicit and resilient.

## What changed
- Added `--dev-manifest` as an explicit alias for `--main` on `check`, `config`, and `list` settings.
- Improved `ManifestChannel.Main` loading to fetch from the main-manifest URL and reliably fall back to embedded stable manifest on failure.
- Hardened manifest/tool validation output in `ToolInfo.Validate` with explicit handling for:
  - missing `check.toolVersion`
  - invalid `check.toolVersion` format
  - required version newer than current tool
- Enabled strict manifest validation in CI (`--ci`) so incompatible manifest/tool combinations fail fast.
- Added deterministic unit coverage:
  - `ToolInfoValidationTests` for strict vs non-strict validation branches
  - `ManifestVersionGuardTests` for embedded manifest SDK/workload invariants
  - `ToolInfoTests` fallback and channel validation updates (including removing network-dependent `Main` from the multi-channel theory)
- Expanded CI matrix coverage with additional `net10` template lanes on Windows and macOS jobs.

## Why
- Prevent silent manifest/tool drift in CI where reliability is critical.
- Keep `main` manifest channel behavior robust under network failures.
- Ensure tests remain deterministic and non-flaky in restricted CI environments.

## Local validation
- `dotnet test .\UnoCheck.Tests\UnoCheck.Tests.csproj --filter "FullyQualifiedName~ToolInfoTests" -v minimal`
- `dotnet test .\UnoCheck.Tests\UnoCheck.Tests.csproj --filter "FullyQualifiedName~ToolInfoValidationTests" -v minimal`
- `dotnet test .\UnoCheck.Tests\UnoCheck.Tests.csproj --filter "FullyQualifiedName~ManifestVersionGuardTests" -v minimal`

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).