### PR TITLE
feat: improve workload install feedback UX

### DIFF
--- a/UnoCheck.Tests/DotNetWorkloadFeedbackTests.cs
+++ b/UnoCheck.Tests/DotNetWorkloadFeedbackTests.cs
@@ -1,0 +1,71 @@
+using DotNetCheck.Checkups;
+using DotNetCheck.DotNet;
+
+namespace UnoCheck.Tests;
+
+public class DotNetWorkloadFeedbackTests
+{
+    [Theory]
+    [InlineData(false, false, false, false, false, true)]
+    [InlineData(true, false, false, false, false, false)]
+    [InlineData(false, true, false, false, false, false)]
+    [InlineData(false, false, true, false, false, false)]
+    [InlineData(false, false, false, true, false, false)]
+    [InlineData(false, false, false, false, true, false)]
+    public void ShouldUseLiveSpinnerFor_ReturnsExpectedValue(
+        bool verbose,
+        bool ci,
+        bool nonInteractive,
+        bool outputRedirected,
+        bool errorRedirected,
+        bool expected)
+    {
+        var actual = DotNetWorkloadsCheckup.ShouldUseLiveSpinnerFor(verbose, ci, nonInteractive, outputRedirected, errorRedirected);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void BuildInstallArgs_AddsDetailedVerbosityWhenVerboseEnabled()
+    {
+        var args = DotNetWorkloadManager.BuildInstallArgs(
+            sdkVersion: "10.0.103",
+            rollbackFile: "c:\\temp\\workload.json",
+            workloadIds: ["wasm-tools"],
+            packageSources: ["https://api.nuget.org/v3/index.json"],
+            verbose: true);
+
+        Assert.Contains("workload", args);
+        Assert.Contains("install", args);
+        Assert.Contains("--verbosity", args);
+        Assert.Contains("detailed", args);
+    }
+
+    [Fact]
+    public void BuildInstallArgs_DoesNotAddVerbosityWhenVerboseDisabled()
+    {
+        var args = DotNetWorkloadManager.BuildInstallArgs(
+            sdkVersion: "10.0.103",
+            rollbackFile: "c:\\temp\\workload.json",
+            workloadIds: ["wasm-tools"],
+            packageSources: ["https://api.nuget.org/v3/index.json"],
+            verbose: false);
+
+        Assert.DoesNotContain("--verbosity", args);
+        Assert.DoesNotContain("detailed", args);
+    }
+
+    [Fact]
+    public void BuildRepairArgs_AddsDetailedVerbosityWhenVerboseEnabled()
+    {
+        var args = DotNetWorkloadManager.BuildRepairArgs(
+            sdkVersion: "10.0.103",
+            packageSources: ["https://api.nuget.org/v3/index.json"],
+            verbose: true);
+
+        Assert.Contains("workload", args);
+        Assert.Contains("repair", args);
+        Assert.Contains("--verbosity", args);
+        Assert.Contains("detailed", args);
+    }
+}

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -63,7 +63,25 @@ namespace DotNetCheck.Cli
 				}
 			}
 
-			var cts = new System.Threading.CancellationTokenSource();
+			using var cts = new System.Threading.CancellationTokenSource();
+			ConsoleCancelEventHandler cancelHandler = (sender, args) =>
+			{
+				if (!cts.IsCancellationRequested)
+				{
+					args.Cancel = true;
+					cts.Cancel();
+					AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Cancellation requested. Stopping current operation...[/]");
+					AnsiConsole.MarkupLine($"[yellow]You can resume later by rerunning {ToolInfo.ToolCommand} --fix.[/]");
+				}
+				else
+				{
+					args.Cancel = false;
+				}
+			};
+			Console.CancelKeyPress += cancelHandler;
+
+			try
+			{
 
 			var checkupStatus = new Dictionary<string, Models.Status>();
 			var sharedState = new SharedState();
@@ -299,6 +317,12 @@ namespace DotNetCheck.Cli
 								Util.Exception(x);
 								AnsiConsole.Markup(adminMsg);
 							}
+							catch (OperationCanceledException)
+							{
+								AnsiConsole.MarkupLine($"[bold yellow]{Icon.Warning} Operation canceled by user.[/]");
+								Environment.ExitCode = 130;
+								return 130;
+							}
 							catch (Exception ex)
 							{
 								Util.Exception(ex);
@@ -380,6 +404,11 @@ namespace DotNetCheck.Cli
 			Environment.ExitCode = exitCode;
 
 			return exitCode;
+			}
+			finally
+			{
+				Console.CancelKeyPress -= cancelHandler;
+			}
 		}
         
         internal static string[] ParseTfmsToTargetPlatforms(CheckSettings settings)

--- a/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
@@ -1,17 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DotNetCheck.DotNet;
 using DotNetCheck.Models;
 using DotNetCheck.Solutions;
 using NuGet.Versioning;
+using Spectre.Console;
+using CheckStatus = DotNetCheck.Models.Status;
 
 namespace DotNetCheck.Checkups
 {
 	public class DotNetWorkloadsCheckup
 		: Checkup
 	{
+		private static readonly string[] HeartbeatFrames = ["|", "/", "-", "\\"];
+
 		private bool _skipMaui = false;
 
         public DotNetWorkloadsCheckup() : base()
@@ -78,6 +84,100 @@ namespace DotNetCheck.Checkups
 
 		public override string Title => $".NET SDK - Workloads ({SdkVersion})";
 
+		internal static bool ShouldUseLiveSpinnerFor(bool verbose, bool ci, bool nonInteractive, bool outputRedirected, bool errorRedirected)
+			=> !verbose
+				&& !ci
+				&& !nonInteractive
+				&& !outputRedirected
+				&& !errorRedirected;
+
+		private static bool ShouldUseLiveSpinner()
+			=> ShouldUseLiveSpinnerFor(Util.Verbose, Util.CI, Util.NonInteractive, Console.IsOutputRedirected, Console.IsErrorRedirected);
+
+		private static string FormatElapsed(TimeSpan duration)
+			=> $"{(int)duration.TotalHours:00}:{duration:mm\\:ss}";
+
+		private static async Task RunWithHeartbeat(Solution solution, string operationName, CancellationToken cancellationToken, Func<CancellationToken, Task> operation)
+		{
+			var elapsed = Stopwatch.StartNew();
+
+			if (ShouldUseLiveSpinner())
+			{
+				using var spinnerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+				await AnsiConsole.Status()
+					.Spinner(Spinner.Known.Dots)
+					.StartAsync($"{operationName}... elapsed 00:00:00", async context =>
+					{
+						var spinnerTask = Task.Run(async () =>
+						{
+							while (!spinnerCancellation.IsCancellationRequested)
+							{
+								await Task.Delay(TimeSpan.FromSeconds(1), spinnerCancellation.Token);
+								if (spinnerCancellation.IsCancellationRequested)
+								{
+									break;
+								}
+
+								context.Status($"{operationName}... elapsed {FormatElapsed(elapsed.Elapsed)}");
+							}
+						}, CancellationToken.None);
+
+						try
+						{
+							await operation(cancellationToken);
+						}
+						finally
+						{
+							spinnerCancellation.Cancel();
+							try
+							{
+								await spinnerTask;
+							}
+							catch (OperationCanceledException)
+							{
+							}
+						}
+					});
+
+				return;
+			}
+
+			using var heartbeatCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+			var heartbeatTask = Task.Run(async () =>
+			{
+				var frameIndex = 0;
+				while (!heartbeatCancellation.IsCancellationRequested)
+				{
+					await Task.Delay(TimeSpan.FromSeconds(10), heartbeatCancellation.Token);
+					if (heartbeatCancellation.IsCancellationRequested)
+					{
+						break;
+					}
+
+					var frame = HeartbeatFrames[frameIndex++ % HeartbeatFrames.Length];
+					solution.ReportStatus($"{frame} {operationName} is still running... elapsed {FormatElapsed(elapsed.Elapsed)}.");
+				}
+			}, CancellationToken.None);
+
+			try
+			{
+				await operation(cancellationToken);
+			}
+			finally
+			{
+				heartbeatCancellation.Cancel();
+				try
+				{
+					await heartbeatTask;
+				}
+				catch (OperationCanceledException)
+				{
+				}
+			}
+		}
+
 		static bool wasForceRunAlready = false;
 
 		public override async Task<DiagnosticResult> Examine(SharedState history)
@@ -126,11 +226,11 @@ namespace DotNetCheck.Checkups
 					&& installedWorkloads.Contains(rp.Id)
 				)
 				{
-					ReportStatus($"{available.id} ({available.version}/{available.sdkVersion}) is installed.", Status.Ok);
+					ReportStatus($"{available.id} ({available.version}/{available.sdkVersion}) is installed.", CheckStatus.Ok);
 				}
 				else
 				{
-					ReportStatus($"{rp.Id} ({rp.PackageId} : {rp.Version}) is not installed.", Status.Error);
+					ReportStatus($"{rp.Id} ({rp.PackageId} : {rp.Version}) is not installed.", CheckStatus.Error);
 					missingWorkloads.Add(rp);
 				}
 			}
@@ -141,24 +241,40 @@ namespace DotNetCheck.Checkups
 			var genericWorkloadManager = new DotNetWorkloadManager(SdkRoot, sdkVersion, NuGetPackageSources);
 
 			return new DiagnosticResult(
-				Status.Error,
+				CheckStatus.Error,
 				this,
 				new Suggestion("Install or Update SDK Workloads",
 				new ActionSolution(async (sln, cancel) =>
 				{
+					sln.ReportStatus("Installing .NET workloads. This can take a long time depending on network speed, cache state, and package source availability.");
+
 					if (history.GetEnvironmentVariableFlagSet("DOTNET_FORCE"))
 					{
 						try
 						{
-							await genericWorkloadManager.Repair();
+							await RunWithHeartbeat(sln, "Repairing workloads", cancel, token => genericWorkloadManager.Repair(token));
 						}
-						catch (Exception ex)
+						catch (OperationCanceledException)
 						{
-							ReportStatus("Warning: Workload repair failed", Status.Warning);
+							sln.ReportStatus("Workload repair was canceled. You can rerun `uno-check --fix` when you're ready to continue.");
+							throw;
+						}
+						catch (Exception)
+						{
+							ReportStatus("Warning: Workload repair failed", CheckStatus.Warning);
 						}
 					}
 
-					await genericWorkloadManager.Install(RequiredWorkloads);
+					try
+					{
+						await RunWithHeartbeat(sln, "Installing workloads", cancel, token => genericWorkloadManager.Install(RequiredWorkloads, token));
+					}
+					catch (OperationCanceledException)
+					{
+						sln.ReportStatus("Workload installation was canceled. You can rerun `uno-check --fix` to resume later.");
+						throw;
+					}
+
 					history.ContributeState(StateKey.EntryPoint, StateKey.ShouldRestartVs, true);
 				})));
 		}

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -50,16 +50,63 @@ namespace DotNetCheck.DotNet
 
 		readonly string DotNetCliWorkingDir;
 
-		public async Task Repair()
+		public async Task Repair(CancellationToken cancellationToken = default)
 		{
-			await CliRepair();
+			await CliRepair(cancellationToken);
 		}
 
-		public async Task Install(Manifest.DotNetWorkload[] workloads)
+		public async Task Install(Manifest.DotNetWorkload[] workloads, CancellationToken cancellationToken = default)
 		{
 			var rollbackFile = WriteRollbackFile(workloads);
 
-			await CliInstallWithRollback(rollbackFile, workloads.Where(w => !w.Abstract).Select(w => w.Id));
+			await CliInstallWithRollback(rollbackFile, workloads.Where(w => !w.Abstract).Select(w => w.Id), cancellationToken);
+		}
+
+		internal static string[] BuildInstallArgs(string sdkVersion, string rollbackFile, IEnumerable<string> workloadIds, IEnumerable<string> packageSources, bool verbose)
+		{
+			var addSourceArg = "--source";
+			if (NuGetVersion.Parse(sdkVersion) <= DotNetCheck.Manifest.DotNetSdk.Version6Preview6)
+				addSourceArg = "--add-source";
+
+			var args = new List<string>
+			{
+				"workload",
+				"install",
+				"--from-rollback-file",
+				$"\"{rollbackFile}\""
+			};
+			args.AddRange(workloadIds);
+			args.AddRange(packageSources.Select(ps => $"{addSourceArg} \"{ps}\""));
+
+			if (verbose)
+			{
+				args.Add("--verbosity");
+				args.Add("detailed");
+			}
+
+			return args.ToArray();
+		}
+
+		internal static string[] BuildRepairArgs(string sdkVersion, IEnumerable<string> packageSources, bool verbose)
+		{
+			var addSourceArg = "--source";
+			if (NuGetVersion.Parse(sdkVersion) <= DotNetCheck.Manifest.DotNetSdk.Version6Preview6)
+				addSourceArg = "--add-source";
+
+			var args = new List<string>
+			{
+				"workload",
+				"repair"
+			};
+			args.AddRange(packageSources.Select(ps => $"{addSourceArg} \"{ps}\""));
+
+			if (verbose)
+			{
+				args.Add("--verbosity");
+				args.Add("detailed");
+			}
+
+			return args.ToArray();
 		}
 
 		string WriteRollbackFile(Manifest.DotNetWorkload[] workloads)
@@ -149,51 +196,34 @@ namespace DotNetCheck.DotNet
 				.ToArray();
 		}
 
-		async Task CliInstallWithRollback(string rollbackFile, IEnumerable<string> workloadIds)
+		async Task CliInstallWithRollback(string rollbackFile, IEnumerable<string> workloadIds, CancellationToken cancellationToken)
 		{
 			// dotnet workload install id --skip-manifest-update --add-source x
 			var dotnetExe = Path.Combine(SdkRoot, DotNetSdk.DotNetExeName);
 
-			// Arg switched to --source in >= preview 7
-			var addSourceArg = "--source";
-			if (NuGetVersion.Parse(SdkVersion) <= DotNetCheck.Manifest.DotNetSdk.Version6Preview6)
-				addSourceArg = "--add-source";
+			var args = BuildInstallArgs(SdkVersion, rollbackFile, workloadIds, NuGetPackageSources, Util.Verbose);
 
-			var args = new List<string>
-			{
-				"workload",
-				"install",
-				"--from-rollback-file",
-				$"\"{rollbackFile}\""
-			};
-			args.AddRange(workloadIds);
-			args.AddRange(NuGetPackageSources.Select(ps => $"{addSourceArg} \"{ps}\""));
+			var r = await Util.WrapShellCommandWithSudo(dotnetExe, DotNetCliWorkingDir, Util.Verbose, cancellationToken, args);
 
-			var r = await Util.WrapShellCommandWithSudo(dotnetExe, DotNetCliWorkingDir, Util.Verbose, args.ToArray());
+			if (cancellationToken.IsCancellationRequested)
+				throw new OperationCanceledException(cancellationToken);
 
 			// Throw if this failed with a bad exit code
 			if (r.ExitCode != 0)
 				throw new Exception("Workload Install failed: `dotnet " + string.Join(' ', args) + "`");
 		}
 
-		async Task CliRepair()
+		async Task CliRepair(CancellationToken cancellationToken)
 		{
 			// dotnet workload install id --skip-manifest-update --add-source x
 			var dotnetExe = Path.Combine(SdkRoot, DotNetSdk.DotNetExeName);
 
-			// Arg switched to --source in >= preview 7
-			var addSourceArg = "--source";
-			if (NuGetVersion.Parse(SdkVersion) <= DotNetCheck.Manifest.DotNetSdk.Version6Preview6)
-				addSourceArg = "--add-source";
+			var args = BuildRepairArgs(SdkVersion, NuGetPackageSources, Util.Verbose);
 
-			var args = new List<string>
-			{
-				"workload",
-				"repair"
-			};
-			args.AddRange(NuGetPackageSources.Select(ps => $"{addSourceArg} \"{ps}\""));
+			var r = await Util.WrapShellCommandWithSudo(dotnetExe, DotNetCliWorkingDir, Util.Verbose, cancellationToken, args);
 
-			var r = await Util.WrapShellCommandWithSudo(dotnetExe, DotNetCliWorkingDir, Util.Verbose, args.ToArray());
+			if (cancellationToken.IsCancellationRequested)
+				throw new OperationCanceledException(cancellationToken);
 
 			// Throw if this failed with a bad exit code
 			if (r.ExitCode != 0)

--- a/UnoCheck/Process/ShellProcessRunner.cs
+++ b/UnoCheck/Process/ShellProcessRunner.cs
@@ -158,11 +158,23 @@ namespace DotNetCheck
 			{
 				Options.CancellationToken.Register(() =>
 				{
-					try { process.Kill(); }
-					catch { }
-
-					try { process?.Dispose(); }
-					catch { }
+					try
+					{
+						if (process?.HasExited == false)
+						{
+							if (!Util.IsWindows && Options.UseSystemShell)
+							{
+								process.Kill(entireProcessTree: true);
+							}
+							else
+							{
+								process.Kill();
+							}
+						}
+					}
+					catch
+					{
+					}
 				});
 			}
 		}
@@ -181,15 +193,36 @@ namespace DotNetCheck
 
 		public ShellProcessResult WaitForExit()
 		{
+			var exitCode = -1;
+
 			try
 			{
 				process.WaitForExit();
 			} catch (Exception ex) { Util.Exception(ex); }
 
+			try
+			{
+				exitCode = process.ExitCode;
+			}
+			catch (ObjectDisposedException)
+			{
+				exitCode = -1;
+			}
+			finally
+			{
+				try
+				{
+					process.Dispose();
+				}
+				catch
+				{
+				}
+			}
+
 			if (standardError?.Any(l => l?.Contains("error: more than one device/emulator") ?? false) ?? false)
 				throw new Exception("More than one Device/Emulator detected, you must specify which Serial to target.");
 
-			return new ShellProcessResult(standardOutput, standardError, process.ExitCode);
+			return new ShellProcessResult(standardOutput, standardError, exitCode);
 		}
 
 		public class ShellProcessResult

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -204,15 +204,21 @@ namespace DotNetCheck
 		}
 
 		public static Task<ShellProcessRunner.ShellProcessResult> ShellCommand(string cmd, string workingDir, bool verbose, string[] args)
+			=> ShellCommand(cmd, workingDir, verbose, System.Threading.CancellationToken.None, args);
+
+		public static Task<ShellProcessRunner.ShellProcessResult> ShellCommand(string cmd, string workingDir, bool verbose, System.Threading.CancellationToken cancellationToken, string[] args)
 		{
-			var cli = new ShellProcessRunner(new ShellProcessRunnerOptions(cmd, string.Join(" ", args)) { WorkingDirectory = workingDir, Verbose = verbose } );
+			var cli = new ShellProcessRunner(new ShellProcessRunnerOptions(cmd, string.Join(" ", args), cancellationToken) { WorkingDirectory = workingDir, Verbose = verbose } );
 			return Task.FromResult(cli.WaitForExit());
 		}
 
 		public static Task<ShellProcessRunner.ShellProcessResult> WrapShellCommandWithSudo(string cmd, string[] args)
-			=> WrapShellCommandWithSudo(cmd, null, false, args);
+			=> WrapShellCommandWithSudo(cmd, null, false, System.Threading.CancellationToken.None, args);
 
-        public static Task<ShellProcessRunner.ShellProcessResult> WrapShellCommandWithSudo(string cmd, string workingDir, bool verbose, string[] args)
+		public static Task<ShellProcessRunner.ShellProcessResult> WrapShellCommandWithSudo(string cmd, string workingDir, bool verbose, string[] args)
+			=> WrapShellCommandWithSudo(cmd, workingDir, verbose, System.Threading.CancellationToken.None, args);
+
+		public static Task<ShellProcessRunner.ShellProcessResult> WrapShellCommandWithSudo(string cmd, string workingDir, bool verbose, System.Threading.CancellationToken cancellationToken, string[] args)
 		{
 			var actualCmd = cmd;
 			var actualArgs = string.Join(" ", args);
@@ -223,7 +229,7 @@ namespace DotNetCheck
 				actualArgs = $"-c 'sudo {cmd} {actualArgs}'"; 
 			}
 
-			var cli = new ShellProcessRunner(new ShellProcessRunnerOptions(actualCmd, actualArgs) { WorkingDirectory = workingDir, Verbose = verbose } );
+			var cli = new ShellProcessRunner(new ShellProcessRunnerOptions(actualCmd, actualArgs, cancellationToken) { WorkingDirectory = workingDir, Verbose = verbose } );
 			return Task.FromResult(cli.WaitForExit());
 		}
 


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno.check/issues/401

## Summary
Improve workload-install feedback during uno-check --fix so users can see progress/liveness for long operations and recover cleanly when interrupted.

End Result:

https://github.com/user-attachments/assets/565e0774-b0b5-44ce-acbd-a3e8c3ae226b


## Why
Workload installs can run for several minutes with little visible output, which looks stalled and leads to repeated cancellations. This change adds clear runtime feedback and cancellation guidance to reduce confusion and improve operator confidence.

## Changes
- Adds long-running pre-message plus live spinner/elapsed updates (interactive) and heartbeat/elapsed fallback (non-interactive/CI).
- Propagates cancellation tokens through workload install/repair execution and reports resume guidance on Ctrl+C.
- Adds focused tests for spinner gating and workload argument composition (including detailed verbosity).