### PR TITLE
fix: harden workload install completion handling

### DIFF
--- a/UnoCheck.Tests/DotNetWorkloadFeedbackTests.cs
+++ b/UnoCheck.Tests/DotNetWorkloadFeedbackTests.cs
@@ -68,4 +68,42 @@ public class DotNetWorkloadFeedbackTests
         Assert.Contains("--verbosity", args);
         Assert.Contains("detailed", args);
     }
+
+    [Fact]
+    public void BuildCliFailureMessage_WhenDiskIsFull_IncludesActionableGuidance()
+    {
+        var message = DotNetWorkloadManager.BuildCliFailureMessage(
+            operationName: "Workload Install",
+            command: "dotnet workload install ...",
+            output: "Workload installation failed: One or more errors occurred. (No space left on device : '/tmp/foo')");
+
+        Assert.Contains("Insufficient disk space", message);
+        Assert.Contains("temporary folders", message);
+        Assert.Contains("uno-check --fix", message);
+    }
+
+    [Fact]
+    public void BuildCliFailureMessage_WhenDiskIsFullOnWindowsStyleError_IncludesActionableGuidance()
+    {
+        var message = DotNetWorkloadManager.BuildCliFailureMessage(
+            operationName: "Workload Install",
+            command: "dotnet workload install ...",
+            output: "ERROR: There is not enough space on the disk.");
+
+        Assert.Contains("Insufficient disk space", message);
+        Assert.Contains("uno-check --fix", message);
+    }
+
+    [Fact]
+    public void BuildCliFailureMessage_WhenGenericFailure_UsesRelevantFailureLine()
+    {
+        var message = DotNetWorkloadManager.BuildCliFailureMessage(
+            operationName: "Workload Install",
+            command: "dotnet workload install ...",
+            output: "line one\nline two\nWorkload installation failed with exit code 1");
+
+        Assert.Contains("Workload Install failed", message);
+        Assert.Contains("Workload installation failed with exit code 1", message);
+        Assert.Contains("dotnet workload install", message);
+    }
 }

--- a/UnoCheck.Tests/ShellProcessRunnerTests.cs
+++ b/UnoCheck.Tests/ShellProcessRunnerTests.cs
@@ -1,0 +1,198 @@
+using System.Diagnostics;
+using DotNetCheck;
+
+namespace UnoCheck.Tests;
+
+public class ShellProcessRunnerTests
+{
+	[Fact]
+	public void WaitForExit_CapturesStdOutAndStdErr_AndReturnsExitCode()
+	{
+		var (executable, args) = GetShellCommand(
+			"echo out-line && echo err-line 1>&2 && exit 7",
+			"echo out-line & echo err-line 1>&2 & exit /b 7");
+
+		var sut = new ShellProcessRunner(new ShellProcessRunnerOptions(executable, args)
+		{
+			UseSystemShell = false,
+			RedirectOutput = true,
+		});
+
+		var result = sut.WaitForExit();
+
+		Assert.Contains("out-line", string.Join(Environment.NewLine, result.StandardOutput));
+		Assert.Contains("err-line", string.Join(Environment.NewLine, result.StandardError));
+		Assert.Equal(7, result.ExitCode);
+		Assert.False(result.Success);
+	}
+
+	[Fact]
+	public void WaitForExit_UsesTemporaryWorkingDirectory_AndEnvironmentVariables()
+	{
+		using var tempDir = new TemporaryDirectory();
+		var expectedToken = Guid.NewGuid().ToString("N");
+
+		var (executable, args) = GetShellCommand(
+			"pwd && echo $UNOCHECK_TEST_TOKEN",
+			"cd & echo %UNOCHECK_TEST_TOKEN%");
+
+		var sut = new ShellProcessRunner(new ShellProcessRunnerOptions(executable, args)
+		{
+			UseSystemShell = false,
+			RedirectOutput = true,
+			WorkingDirectory = tempDir.Path,
+			EnvironmentVariables = new Dictionary<string, string>
+			{
+				["UNOCHECK_TEST_TOKEN"] = expectedToken,
+			},
+		});
+
+		var result = sut.WaitForExit();
+		var output = string.Join(Environment.NewLine, result.StandardOutput);
+
+		Assert.Equal(0, result.ExitCode);
+		Assert.Contains(expectedToken, output);
+
+		var expectedDirectory = Path.GetFullPath(tempDir.Path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		var normalizedOutput = output
+			.Replace("\\", "/", StringComparison.Ordinal)
+			.Replace("\r", string.Empty, StringComparison.Ordinal)
+			.ToLowerInvariant();
+		var normalizedExpectedDirectory = expectedDirectory
+			.Replace("\\", "/", StringComparison.Ordinal)
+			.ToLowerInvariant();
+
+		Assert.Contains(normalizedExpectedDirectory, normalizedOutput);
+	}
+
+	[Fact]
+	public void WaitForExit_CancellationToken_KillsLongRunningCommand()
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(600));
+		var sw = Stopwatch.StartNew();
+
+		var (executable, args) = GetShellCommand(
+			"echo started && sleep 30 && echo completed",
+			"echo started & ping 127.0.0.1 -n 30 > nul & echo completed");
+
+		var sut = new ShellProcessRunner(new ShellProcessRunnerOptions(executable, args, cts.Token)
+		{
+			UseSystemShell = false,
+			RedirectOutput = true,
+		});
+
+		var result = sut.WaitForExit();
+		sw.Stop();
+
+		var output = string.Join(Environment.NewLine, result.StandardOutput);
+
+		Assert.Contains("started", output);
+		Assert.DoesNotContain("completed", output);
+		Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10), $"Expected cancellation before 10s but took {sw.Elapsed}.");
+		Assert.NotEqual(0, result.ExitCode);
+	}
+
+	[Fact]
+	public void WaitForExit_CapturesIntermittentOutputWithoutHanging()
+	{
+		var (executable, args) = GetShellCommand(
+			"echo retry-1 && sleep 1 && echo retry-2 && sleep 1 && echo completed",
+			"echo retry-1 & ping 127.0.0.1 -n 2 > nul & echo retry-2 & ping 127.0.0.1 -n 2 > nul & echo completed");
+
+		var sut = new ShellProcessRunner(new ShellProcessRunnerOptions(executable, args)
+		{
+			UseSystemShell = false,
+			RedirectOutput = true,
+		});
+
+		var result = sut.WaitForExit();
+		var output = string.Join(Environment.NewLine, result.StandardOutput);
+
+		Assert.True(result.Success);
+		Assert.Contains("retry-1", output);
+		Assert.Contains("retry-2", output);
+		Assert.Contains("completed", output);
+	}
+
+	[Fact]
+	public void WaitForExit_CancellationToken_KillsNeverEndingCommand()
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(800));
+		var sw = Stopwatch.StartNew();
+
+		var (executable, args) = GetNeverEndingCommand();
+
+		var sut = new ShellProcessRunner(new ShellProcessRunnerOptions(executable, args, cts.Token)
+		{
+			UseSystemShell = false,
+			RedirectOutput = true,
+		});
+
+		var result = sut.WaitForExit();
+		sw.Stop();
+
+		var output = string.Join(Environment.NewLine, result.StandardOutput);
+
+		Assert.Contains("started", output);
+		Assert.True(sw.Elapsed < TimeSpan.FromSeconds(12), $"Expected cancellation before 12s but took {sw.Elapsed}.");
+		Assert.NotEqual(0, result.ExitCode);
+	}
+
+	[Fact]
+	public void Run_ReturnsSuccess_ForSimpleCommand()
+	{
+		var (executable, args) = GetShellCommand(
+			"echo hello",
+			"echo hello");
+
+		var result = ShellProcessRunner.Run(executable, args);
+
+		Assert.True(result.Success);
+		Assert.Contains("hello", string.Join(Environment.NewLine, result.StandardOutput));
+	}
+
+	private static (string executable, string args) GetShellCommand(string unixCommand, string windowsCommand)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return ("cmd.exe", $"/d /c \"{windowsCommand}\"");
+		}
+
+		return ("/bin/sh", $"-c \"{unixCommand}\"");
+	}
+
+	private static (string executable, string args) GetNeverEndingCommand()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return ("powershell.exe", "-NoProfile -Command \"Write-Output 'started'; while ($true) { Start-Sleep -Milliseconds 200 }\"");
+		}
+
+		return ("/bin/sh", "-c \"echo started; tail -f /dev/null\"");
+	}
+
+	private sealed class TemporaryDirectory : IDisposable
+	{
+		public TemporaryDirectory()
+		{
+			Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "uno-check-tests", Guid.NewGuid().ToString("N"));
+			Directory.CreateDirectory(Path);
+		}
+
+		public string Path { get; }
+
+		public void Dispose()
+		{
+			try
+			{
+				if (Directory.Exists(Path))
+				{
+					Directory.Delete(Path, recursive: true);
+				}
+			}
+			catch
+			{
+			}
+		}
+	}
+}

--- a/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
@@ -253,6 +253,7 @@ namespace DotNetCheck.Checkups
 						try
 						{
 							await RunWithHeartbeat(sln, "Repairing workloads", cancel, token => genericWorkloadManager.Repair(token));
+							sln.ReportStatus("Workload repair completed.");
 						}
 						catch (OperationCanceledException)
 						{
@@ -268,6 +269,7 @@ namespace DotNetCheck.Checkups
 					try
 					{
 						await RunWithHeartbeat(sln, "Installing workloads", cancel, token => genericWorkloadManager.Install(RequiredWorkloads, token));
+						sln.ReportStatus("Workload installation completed.");
 					}
 					catch (OperationCanceledException)
 					{

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -210,7 +210,7 @@ namespace DotNetCheck.DotNet
 
 			// Throw if this failed with a bad exit code
 			if (r.ExitCode != 0)
-				throw new Exception("Workload Install failed: `dotnet " + string.Join(' ', args) + "`");
+				throw new Exception(BuildCliFailureMessage("Workload Install", "dotnet " + string.Join(' ', args), r.GetOutput()));
 		}
 
 		async Task CliRepair(CancellationToken cancellationToken)
@@ -227,7 +227,51 @@ namespace DotNetCheck.DotNet
 
 			// Throw if this failed with a bad exit code
 			if (r.ExitCode != 0)
-				throw new Exception("Workload Repair failed: `dotnet " + string.Join(' ', args) + "`");
+				throw new Exception(BuildCliFailureMessage("Workload Repair", "dotnet " + string.Join(' ', args), r.GetOutput()));
+		}
+
+		internal static string BuildCliFailureMessage(string operationName, string command, string output)
+		{
+			if (!string.IsNullOrWhiteSpace(output))
+			{
+				if (output.IndexOf("No space left on device", StringComparison.OrdinalIgnoreCase) >= 0
+					|| output.IndexOf("There is not enough space on the disk", StringComparison.OrdinalIgnoreCase) >= 0
+					|| output.IndexOf("disk full", StringComparison.OrdinalIgnoreCase) >= 0
+					|| output.IndexOf("ENOSPC", StringComparison.OrdinalIgnoreCase) >= 0)
+				{
+					return $"{operationName} failed: Insufficient disk space detected. Free disk space (including temporary folders and package caches) and rerun `uno-check --fix`. Command: `{command}`";
+				}
+
+				var lines = output
+					.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+					.Select(line => line.Trim())
+					.Where(line => !string.IsNullOrWhiteSpace(line))
+					.ToArray();
+
+				if (lines.Length > 0)
+				{
+					string keyLine = null;
+
+					for (var i = lines.Length - 1; i >= 0; i--)
+					{
+						var line = lines[i];
+						if (line.IndexOf("error", StringComparison.OrdinalIgnoreCase) >= 0
+							|| line.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0
+							|| line.IndexOf("exception", StringComparison.OrdinalIgnoreCase) >= 0)
+						{
+							keyLine = line;
+							break;
+						}
+					}
+
+					keyLine ??= lines[^1];
+					keyLine = keyLine.TrimEnd('.');
+
+					return $"{operationName} failed: {keyLine}. Command: `{command}`";
+				}
+			}
+
+			return $"{operationName} failed: `{command}`";
 		}
 
 		private string FilterWorkloadCommandOutput(string output, (string begin, string end) marker)

--- a/UnoCheck/Process/ShellProcessRunner.cs
+++ b/UnoCheck/Process/ShellProcessRunner.cs
@@ -48,6 +48,8 @@ namespace DotNetCheck
 
 	public class ShellProcessRunner
 	{
+		private static readonly TimeSpan StreamDrainTimeout = TimeSpan.FromSeconds(2);
+
 		public static string MacOSShell
 			=> File.Exists("/bin/zsh") ? "/bin/zsh" : "/bin/bash";
 
@@ -61,6 +63,8 @@ namespace DotNetCheck
 		readonly List<string> standardError;
 		readonly Process process;
 		readonly bool verbose;
+		readonly TaskCompletionSource<bool> outputReadCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+		readonly TaskCompletionSource<bool> errorReadCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		public readonly ShellProcessRunnerOptions Options;
 
@@ -122,25 +126,31 @@ namespace DotNetCheck
 
 			process.OutputDataReceived += (s, e) =>
 			{
-				if (e.Data != null)
+				if (e.Data == null)
 				{
-					if (verbose)
-						Console.WriteLine(e.Data);
-
-					standardOutput.Add(e.Data);
-					Options?.OutputCallback?.Invoke(e.Data);
+					outputReadCompleted.TrySetResult(true);
+					return;
 				}
+
+				if (verbose)
+					Console.WriteLine(e.Data);
+
+				standardOutput.Add(e.Data);
+				Options?.OutputCallback?.Invoke(e.Data);
 			};
 			process.ErrorDataReceived += (s, e) =>
 			{
-				if (e.Data != null)
+				if (e.Data == null)
 				{
-					if (verbose)
-						Console.WriteLine(e.Data);
-
-					standardError.Add(e.Data);
-					Options?.OutputCallback?.Invoke(e.Data);
+					errorReadCompleted.TrySetResult(true);
+					return;
 				}
+
+				if (verbose)
+					Console.WriteLine(e.Data);
+
+				standardError.Add(e.Data);
+				Options?.OutputCallback?.Invoke(e.Data);
 			};
 
 			if (verbose)
@@ -153,6 +163,11 @@ namespace DotNetCheck
 				process.BeginOutputReadLine();
 				process.BeginErrorReadLine();
 			}
+			else
+			{
+				outputReadCompleted.TrySetResult(true);
+				errorReadCompleted.TrySetResult(true);
+			}
 
 			if (Options.CancellationToken != System.Threading.CancellationToken.None)
 			{
@@ -162,11 +177,11 @@ namespace DotNetCheck
 					{
 						if (process?.HasExited == false)
 						{
-							if (!Util.IsWindows && Options.UseSystemShell)
+							try
 							{
 								process.Kill(entireProcessTree: true);
 							}
-							else
+							catch
 							{
 								process.Kill();
 							}
@@ -197,8 +212,48 @@ namespace DotNetCheck
 
 			try
 			{
-				process.WaitForExit();
-			} catch (Exception ex) { Util.Exception(ex); }
+				while (process?.HasExited == false)
+				{
+					process.WaitForExit(250);
+				}
+			}
+			catch (Exception ex)
+			{
+				Util.Exception(ex);
+			}
+
+			if (Options.RedirectOutput)
+			{
+				var drainCompleted = false;
+
+				try
+				{
+					drainCompleted = Task.WhenAll(outputReadCompleted.Task, errorReadCompleted.Task)
+						.Wait(StreamDrainTimeout);
+				}
+				catch
+				{
+				}
+
+				if (!drainCompleted)
+				{
+					try
+					{
+						process.CancelOutputRead();
+					}
+					catch
+					{
+					}
+
+					try
+					{
+						process.CancelErrorRead();
+					}
+					catch
+					{
+					}
+				}
+			}
 
 			try
 			{


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.check/issues/#401 (and as a follow-up of https://github.com/unoplatform/uno.check/pull/512)

This change hardens process completion in workload installation by waiting for process exit with bounded polling, draining redirected output/error handlers before cleanup, and falling back to canceling reads only when drain does not complete quickly. It also improves user feedback by reporting explicit workload repair/install completion and adds focused runner tests for cancellation, intermittent output, and never-ending command scenarios. This addresses reliability and observability gaps reported in the workload install flow.