### PR TITLE
fix: bump Xcode minimumVersion from 16.4 to 26.2

### DIFF
--- a/manifests/uno.ui-preview-major.manifest.json
+++ b/manifests/uno.ui-preview-major.manifest.json
@@ -23,7 +23,7 @@
       }
     },
     "xcode": {
-      "minimumVersion": "16.4"
+      "minimumVersion": "26.2"
     },
     "vswin": {
       "minimumVersion": "18.0"

--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -23,7 +23,7 @@
       }
     },
     "xcode": {
-      "minimumVersion": "16.4"
+      "minimumVersion": "26.2"
     },
     "vswin": {
       "minimumVersion": "18.0"

--- a/manifests/uno.ui.manifest.json
+++ b/manifests/uno.ui.manifest.json
@@ -23,7 +23,7 @@
       }
     },
     "xcode": {
-      "minimumVersion": "16.4"
+      "minimumVersion": "26.2"
     },
     "vswin": {
       "minimumVersion": "18.0"


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno.check/issues/508
Fixes https://github.com/unoplatform/uno.check/issues/514
Related to https://github.com/unoplatform/uno/issues/21912

## Summary

Bumps the Xcode `minimumVersion` from `16.4` to `26.2` in all three manifest files (`uno.ui.manifest.json`, `uno.ui-preview.manifest.json`, `uno.ui-preview-major.manifest.json`).

## Why

The .NET 10 iOS workload (`26.2.10217`) shipped with the official .NET SDK 10.0.200 requires Xcode 26.2. Users with Xcode 26.0 get misleading build/deploy failures on iOS 26 simulators:

- `Failed to find matching arch`
- `Needs to Be Updated`

Without this bump, `uno-check` does not flag the outdated Xcode installation.

## Evidence

- [dotnet/macios release (authoritative)](https://github.com/dotnet/macios/releases/tag/dotnet-10.0.1xx-xcode26.2-10217): ".NET 10 - Xcode 26.2 support (26.2.10217)" — tagged as **Latest** (not pre-release), explicitly states "Xcode 26.2 is required with this release", install via workload set `10.0.200`.
- [NuGet package](https://www.nuget.org/packages/Microsoft.iOS.Sdk.net10.0_26.2/26.2.10217): `Microsoft.iOS.Sdk.net10.0_26.2` v`26.2.10217` — stable (no pre-release suffix), 408K+ downloads.
- **Local SDK**: `dotnet workload list` confirms iOS `26.2.10217/10.0.100` installed via SDK 10.0.200.
- **Manual verification**: Xcode 26.2 + Uno SDK 6.5.31 + iOS 26.3.1 simulator confirmed working from Windows via Rider.

## Changes

| File | Change |
|------|--------|
| `manifests/uno.ui.manifest.json` | `16.4` → `26.2` |
| `manifests/uno.ui-preview.manifest.json` | `16.4` → `26.2` |
| `manifests/uno.ui-preview-major.manifest.json` | `16.4` → `26.2` |

No code changes needed — `XCodeCheckup.cs` already uses `NuGetVersion >=` comparison which handles the `16.x` → `26.x` jump correctly.