### PR TITLE
chore: bump to net11 pre2

### DIFF
--- a/UnoCheck/Telemetry/TelemetryClient.cs
+++ b/UnoCheck/Telemetry/TelemetryClient.cs
@@ -42,7 +42,7 @@ internal static class TelemetryClient
                 requestedFrameworks?
                     .OrderBy(s => s)
                     .Where(f => System.Text.RegularExpressions.Regex.IsMatch(f, @"^net\d+(\.0)(?:-[a-zA-Z0-9.]+)*$"))
-                    .Select(s => s[..32])
+                    .Select(s => s.Length >= 32 ? s[..32] : s)
                     .Take(10) ?? []);
 
             _telemetry.TrackEvent(

--- a/manifests/uno.ui-preview-major.manifest.json
+++ b/manifests/uno.ui-preview-major.manifest.json
@@ -3,13 +3,13 @@
     "toolVersion": "1.14.0",
     "variables": {
       "OPENJDK_VERSION": "17.0.16",
-      "DOTNET_SDK_VERSION": "10.0.201",
-      "MACCATALYST_SDK_VERSION": "26.2.10217/10.0.100",
-      "IOS_SDK_VERSION": "26.2.10217/10.0.100",
-      "TVOS_SDK_VERSION": "26.2.10217/10.0.100",
-      "ANDROID_SDK_VERSION": "36.1.43/10.0.100",
-      "MAUI_VERSION": "10.0.20/10.0.100",
-      "WASMTOOLS_VERSION": "10.0.105/10.0.100"
+      "DOTNET_SDK_VERSION": "11.0.100-preview.2.26159.112",
+      "MACCATALYST_SDK_VERSION": "26.2.11425-net11-p2/11.0.100-preview.2",
+      "IOS_SDK_VERSION": "26.2.11425-net11-p2/11.0.100-preview.2",
+      "TVOS_SDK_VERSION": "26.2.11425-net11-p2/11.0.100-preview.2",
+      "ANDROID_SDK_VERSION": "36.1.99-preview.2.154/11.0.100-preview.2",
+      "MAUI_VERSION": "11.0.0-preview.2.26152.10/11.0.100-preview.2",
+      "WASMTOOLS_VERSION": "11.0.100-preview.2.26159.112/11.0.100-preview.2"
     },
     "variableMappers": [
     ],
@@ -93,56 +93,56 @@
             "osxArm64": "https://builds.dotnet.microsoft.com/dotnet/Sdk/$(DOTNET_SDK_VERSION)/dotnet-sdk-$(DOTNET_SDK_VERSION)-osx-arm64.pkg"
           },
           "packageSources": [
-            "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json",
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json",
             "https://api.nuget.org/v3/index.json"
           ],
           "workloads": [
             {
               "workloadId": "android",
               "workloadManifestId": "microsoft.net.sdk.android",
-              "packageId": "Microsoft.NET.Sdk.Android.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Sdk.Android.Manifest-11.0.100-preview.2",
               "version": "$(ANDROID_SDK_VERSION)",
               "supportedPlatforms": [ "Windows", "OSX", "Linux/x64" ]
             },
             {
               "workloadId": "ios",
               "workloadManifestId": "microsoft.net.sdk.ios",
-              "packageId": "Microsoft.NET.Sdk.iOS.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Sdk.iOS.Manifest-11.0.100-preview.2",
               "version": "$(IOS_SDK_VERSION)",
               "supportedPlatforms": [ "Windows", "OSX" ]
             },
             {
               "workloadId": "maccatalyst",
               "workloadManifestId": "microsoft.net.sdk.maccatalyst",
-              "packageId": "Microsoft.NET.Sdk.MacCatalyst.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Sdk.MacCatalyst.Manifest-11.0.100-preview.2",
               "version": "$(MACCATALYST_SDK_VERSION)",
               "supportedPlatforms": [ "Windows", "OSX" ]
             },
             {
               "workloadId": "tvos",
               "workloadManifestId": "microsoft.net.sdk.tvos",
-              "packageId": "Microsoft.NET.Sdk.tvos.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Sdk.tvos.Manifest-11.0.100-preview.2",
               "version": "$(TVOS_SDK_VERSION)",
               "supportedPlatforms": [ "Windows", "OSX" ]
             },
             {
               "workloadId": "maui",
               "workloadManifestId": "microsoft.net.sdk.maui",
-              "packageId": "Microsoft.NET.Sdk.Maui.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Sdk.Maui.Manifest-11.0.100-preview.2",
               "version": "$(MAUI_VERSION)",
               "supportedPlatforms": [ "Windows", "OSX" ]
             },
             {
               "workloadId": "maui-android",
               "workloadManifestId": "microsoft.net.sdk.maui",
-              "packageId": "Microsoft.NET.Sdk.Maui.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Sdk.Maui.Manifest-11.0.100-preview.2",
               "version": "$(MAUI_VERSION)",
               "supportedPlatforms": [ "Linux/x64" ]
             },
             {
               "workloadId": "wasm-tools",
               "workloadManifestId": "microsoft.net.workload.mono.toolchain.current",
-              "packageId": "Microsoft.NET.Workload.Mono.ToolChain.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest-11.0.100-preview.2",
               "version": "$(WASMTOOLS_VERSION)",
               "supportedPlatforms": [ "Windows", "OSX", "Linux/x64", "Linux/arm64" ]
             }


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/issues/22745
Context: https://devblogs.microsoft.com/dotnet/dotnet-11-preview-2/

Update `manifests/uno.ui-preview-major.manifest.json` to list .NET 11 Preview 2 workload versions.

Additionally, while trying to test this locally:

	dotnet build
	dotnet UnoCheck/bin/Debug/net6.0/UnoCheck.dll check --verbose --preview-major --tfm net11.0-ios --tfm net11.0-android

I observed an exception:

	Telemetry failure: System.ArgumentOutOfRangeException: Index and length must refer to a location within the string. (Parameter 'length')
	   at System.String.ThrowSubstringArgumentOutOfRange(Int32 startIndex, Int32 length)
	   at System.String.Substring(Int32 startIndex, Int32 length)
	   at DotNetCheck.TelemetryClient.<>c.<TrackStartCheck>b__3_2(String s) in …/unoplatform/uno.check/UnoCheck/Telemetry/TelemetryClient.cs:line 45
	   at System.Linq.Enumerable.IEnumerableWhereSelectIterator`2.MoveNext()
	   at System.Linq.Enumerable.IEnumerableSkipTakeIterator`1.MoveNext()
	   at System.String.Join(String separator, IEnumerable`1 values)
	   at DotNetCheck.TelemetryClient.TrackStartCheck(String[] requestedFrameworks) in …/unoplatform/uno.check/UnoCheck/Telemetry/TelemetryClient.cs:line 40

This is due to the `.Select(s => s[..32])`, which requires that `s` be at least 32 characters long.  It was processing `net11.0-ios`, which is *not* 32 characters long.  Remove the `.Select()` to fix this.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- ✨ Feature
- 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

.NET 11 is not supported.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior? 🚀

.NET 11 is now supported.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [X] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->