### PR TITLE
chore: upgrade manifests to .NET SDK 10.0.300 + .NET 11 preview 4 + Xcode 26.5/26.4

### DIFF
--- a/manifests/uno.ui-preview-major.manifest.json
+++ b/manifests/uno.ui-preview-major.manifest.json
@@ -2,8 +2,8 @@
   "check": {
     "toolVersion": "1.14.0",
     "variables": {
-      "OPENJDK_VERSION": "17.0.16",
-      "DOTNET_SDK_VERSION": "11.0.100-preview.4.26230.115",
+      "OPENJDK_VERSION": "17.0.19",
+      "DOTNET_SDK_VERSION": "11.0.100-preview.4.26261.2",
       "MACCATALYST_SDK_VERSION": "26.4.11514-net11-p4/11.0.100-preview.4",
       "IOS_SDK_VERSION": "26.4.11514-net11-p4/11.0.100-preview.4",
       "TVOS_SDK_VERSION": "26.4.11514-net11-p4/11.0.100-preview.4",
@@ -14,7 +14,7 @@
     "variableMappers": [
     ],
     "openjdk": {
-      "version": "17.0.16",
+      "version": "17.0.19",
       "urls": {
         "win64": "https://aka.ms/download-jdk/microsoft-jdk-$(OPENJDK_VERSION)-windows-x64.msi",
         "winArm64": "https://aka.ms/download-jdk/microsoft-jdk-$(OPENJDK_VERSION)-windows-aarch64.msi",

--- a/manifests/uno.ui-preview-major.manifest.json
+++ b/manifests/uno.ui-preview-major.manifest.json
@@ -2,7 +2,7 @@
   "check": {
     "toolVersion": "1.14.0",
     "variables": {
-      "OPENJDK_VERSION": "17.0.16",
+      "OPENJDK_VERSION": "17.0.19",
       "DOTNET_SDK_VERSION": "11.0.100-preview.7.26381.103",
       "MACCATALYST_SDK_VERSION": "26.5.11997-net11-p7/11.0.100-preview.7",
       "IOS_SDK_VERSION": "26.5.11997-net11-p7/11.0.100-preview.7",
@@ -14,7 +14,7 @@
     "variableMappers": [
     ],
     "openjdk": {
-      "version": "17.0.16",
+      "version": "17.0.19",
       "urls": {
         "win64": "https://aka.ms/download-jdk/microsoft-jdk-$(OPENJDK_VERSION)-windows-x64.msi",
         "winArm64": "https://aka.ms/download-jdk/microsoft-jdk-$(OPENJDK_VERSION)-windows-aarch64.msi",

--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -2,19 +2,19 @@
   "check": {
     "toolVersion": "1.14.0",
     "variables": {
-      "OPENJDK_VERSION": "17.0.16",
-      "DOTNET_SDK_VERSION": "10.0.201",
-      "MACCATALYST_SDK_VERSION": "26.2.10217/10.0.100",
-      "IOS_SDK_VERSION": "26.2.10217/10.0.100",
-      "TVOS_SDK_VERSION": "26.2.10217/10.0.100",
-      "ANDROID_SDK_VERSION": "36.1.43/10.0.100",
+      "OPENJDK_VERSION": "17.0.19",
+      "DOTNET_SDK_VERSION": "10.0.300",
+      "MACCATALYST_SDK_VERSION": "26.5.10280/10.0.100",
+      "IOS_SDK_VERSION": "26.5.10280/10.0.100",
+      "TVOS_SDK_VERSION": "26.5.10280/10.0.100",
+      "ANDROID_SDK_VERSION": "36.1.53/10.0.100",
       "MAUI_VERSION": "10.0.20/10.0.100",
-      "WASMTOOLS_VERSION": "10.0.105/10.0.100"
+      "WASMTOOLS_VERSION": "10.0.108/10.0.100"
     },
     "variableMappers": [
     ],
     "openjdk": {
-      "version": "17.0.16",
+      "version": "17.0.19",
       "urls": {
         "win64": "https://aka.ms/download-jdk/microsoft-jdk-$(OPENJDK_VERSION)-windows-x64.msi",
         "winArm64": "https://aka.ms/download-jdk/microsoft-jdk-$(OPENJDK_VERSION)-windows-aarch64.msi",
@@ -23,7 +23,7 @@
       }
     },
     "xcode": {
-      "minimumVersion": "26.2"
+      "minimumVersion": "26.5"
     },
     "vswin": {
       "minimumVersion": "18.0"

--- a/manifests/uno.ui.manifest.json
+++ b/manifests/uno.ui.manifest.json
@@ -2,19 +2,19 @@
   "check": {
     "toolVersion": "1.14.0",
     "variables": {
-      "OPENJDK_VERSION": "17.0.16",
-      "DOTNET_SDK_VERSION": "10.0.201",
-      "MACCATALYST_SDK_VERSION": "26.2.10217/10.0.100",
-      "IOS_SDK_VERSION": "26.2.10217/10.0.100",
-      "TVOS_SDK_VERSION": "26.2.10217/10.0.100",
-      "ANDROID_SDK_VERSION": "36.1.43/10.0.100",
+      "OPENJDK_VERSION": "17.0.19",
+      "DOTNET_SDK_VERSION": "10.0.300",
+      "MACCATALYST_SDK_VERSION": "26.5.10280/10.0.100",
+      "IOS_SDK_VERSION": "26.5.10280/10.0.100",
+      "TVOS_SDK_VERSION": "26.5.10280/10.0.100",
+      "ANDROID_SDK_VERSION": "36.1.53/10.0.100",
       "MAUI_VERSION": "10.0.20/10.0.100",
-      "WASMTOOLS_VERSION": "10.0.105/10.0.100"
+      "WASMTOOLS_VERSION": "10.0.108/10.0.100"
     },
     "variableMappers": [
     ],
     "openjdk": {
-      "version": "17.0.16",
+      "version": "17.0.19",
       "urls": {
         "win64": "https://aka.ms/download-jdk/microsoft-jdk-$(OPENJDK_VERSION)-windows-x64.msi",
         "winArm64": "https://aka.ms/download-jdk/microsoft-jdk-$(OPENJDK_VERSION)-windows-aarch64.msi",
@@ -23,7 +23,7 @@
       }
     },
     "xcode": {
-      "minimumVersion": "26.2"
+      "minimumVersion": "26.5"
     },
     "vswin": {
       "minimumVersion": "18.0"


### PR DESCRIPTION
## Summary

Bumps all three workload manifests to the latest published versions (current as of 2026-05-19):

| Channel | DOTNET_SDK | iOS / MacCat / tvos | Android | MAUI | wasm-tools | Xcode min |
|---|---|---|---|---|---|---|
| stable (`uno.ui.manifest.json`) | `10.0.201` → `10.0.300` | `26.2.10217` → `26.5.10280` | `36.1.43` → `36.1.53` | `10.0.20` (unchanged) | `10.0.105` → `10.0.108` | `26.2` → `26.5` |
| preview (`uno.ui-preview.manifest.json`) | mirror of stable | mirror | mirror | mirror | mirror | mirror |
| preview-major (`uno.ui-preview-major.manifest.json`) | net11 preview.3 → **preview.4** (`11.0.100-preview.4.26261.2`) | `26.2.11588-net11-p3` → `26.4.11514-net11-p4` | `preview.3.10` → `preview.4.137` | `preview.3.26203.7` → `preview.4.26230.3` | `preview.3.26207.106` → `preview.4.26230.115` | `26.2` → `26.4` |

OpenJDK bumped from `17.0.16` → `17.0.19` (April 2026 patch) in all three manifests.

## Why these specific versions

- **.NET 10 SDK `10.0.300`**: latest stable feature band (released 2026-05-12 as `10.0.8`). Workload manifest `packageId` suffixes stay on `Manifest-10.0.100` — band-300 packages aren't published; the workload manifest is anchored to the introducing band.
- **iOS workload `26.5.10280`** is the one that targets Xcode 26.5 (per [.NET for iOS Xcode requirement doc](https://learn.microsoft.com/en-us/dotnet/ios/troubleshooting/xcode-requirement)). Bumping the workload requires bumping the Xcode pin together.
- **.NET 11 preview 4 iOS workload `26.4.11514-net11-p4`** targets Xcode 26.4 — that's why preview-major's Xcode pin is lower than stable's. The .NET 11 p4 workload was built against Xcode 26.4 before 26.5 shipped.
- **OpenJDK 17.0.19**: April 2026 quarterly patch, current LTS. Stays on 17.x (per OpenJdkCheckup compatibility).

## Xcode pins are floors, not exact matches

All three manifests use `xcode.minimumVersion`, consistent with every Xcode bump since `def5249`. `Extensions.IsCompatible` (`UnoCheck/Extensions.cs:9-15`) treats this as `installed_version >= minimumVersion`. It is **not** a strict equality check — `exactVersion` exists in the schema but is intentionally not used here.

Practical consequence for the preview-major channel: a developer on Xcode 26.5 (latest stable) will pass `uno-check --preview-major`, but `dotnet build` for a net11-preview-4 iOS project will then fail with .NET-for-iOS's own "requires Xcode 26.4" error. That stricter major.minor matching is enforced by the .NET for iOS runtime; uno.check's role is to flag the floor (missing Xcode entirely, or an older version), not to duplicate Microsoft's match check. Asking macOS devs to keep an older Xcode side-by-side just for the experimental channel would be a regression.

If we ever want to make the pre-flight check match runtime behavior, that's a separate change (switch to `exactVersion`/`exactVersionName`) and a convention shift worth its own discussion.

## Compatibility / breaking changes

- macOS users below **26.2 (Tahoe)** cannot install Xcode 26.5 and will be blocked on `uno-check check` for the stable channel.
- Users on `--preview-major` need at least Xcode 26.4. If they only have Xcode 26.5, uno-check passes but the .NET 11 p4 iOS build will reject 26.5 — by design (see above).

## Test plan

- [x] `dotnet restore UnoCheck.sln --ignore-failed-sources`
- [x] `dotnet build UnoCheck.sln -c Release` — 0 errors
- [x] `dotnet test UnoCheck.Tests/UnoCheck.Tests.csproj --no-build -c Release` — 85/86 pass (the 1 failure is the pre-existing `net9.0-desktop`→`win32` platform-dependent assertion, tracked separately)
- [x] `dotnet test --filter "FullyQualifiedName~ManifestVersionGuardTests|FullyQualifiedName~ManifestTests"` — 13/13 pass (format guards confirm `WASMTOOLS_VERSION` shape and wasm-tools presence in all three manifests)
- [ ] CI matrix (Windows / macOS-14 / Linux) — pending on push
- [ ] Local smoke test against a real macOS with Xcode 26.5: `uno-check check --verbose --tfm net10.0-ios --tfm net10.0-android`
- [ ] Local smoke test for preview-major: `uno-check check --verbose --preview-major --tfm net11.0-ios --tfm net11.0-android` (watch for telemetry-substring-style regressions per commit 0af05bf)

## Out of scope (follow-ups)

- CI workflow rows for net10/net11 TFMs (still validates today's matrix; expansion can be a separate PR).
- Resolving the pre-existing TFM-desktop test bug (already deferred to its own PR off main).
- Switching Xcode pins to `exactVersion` (would change the pre-flight semantics; worth a separate discussion).