### PR TITLE
feat: add WinApp CLI install check

### DIFF
--- a/UnoCheck/Checkups/WinAppCliCheckup.cs
+++ b/UnoCheck/Checkups/WinAppCliCheckup.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+
+using DotNetCheck.Models;
+using DotNetCheck.Solutions;
+
+namespace DotNetCheck.Checkups
+{
+	internal class WinAppCliCheckup : Checkup
+	{
+		private const string SuggestionMessage = "WinApp CLI is not installed. To learn more visit https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/";
+
+		public override string Id => "winappcli";
+
+		public override string Title => "WinApp CLI";
+
+		public override bool IsPlatformSupported(Platform platform) => platform == Platform.Windows;
+
+		public override bool ShouldExamine(SharedState history)
+			=> Manifest?.Check?.VSWin != null;
+
+		public override Task<DiagnosticResult> Examine(SharedState history)
+		{
+			var result = new ShellProcessRunner(new("winapp", "--version") { Verbose = true }).WaitForExit();
+
+			if (result.Success)
+			{
+				var version = string.Join(" ", result.StandardOutput).Trim();
+				ReportStatus(
+					string.IsNullOrEmpty(version)
+						? "WinApp CLI is installed."
+						: $"WinApp CLI {version} is installed.",
+					Status.Ok);
+				return Task.FromResult(DiagnosticResult.Ok(this));
+			}
+
+			return Task.FromResult(new DiagnosticResult(
+				Status.Error,
+				this,
+				"WinApp CLI is not installed.",
+				new Suggestion(SuggestionMessage, new WinAppCliInstallSolution())));
+		}
+	}
+}

--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -52,7 +52,8 @@ namespace DotNetCheck
 				new HyperVCheckup(),
 				new DotNetNewUnoTemplatesCheckup(),
 				new UnoSdkCheckup(),
-				new EdgeWebView2Checkup()
+				new EdgeWebView2Checkup(),
+				new WinAppCliCheckup()
 			);
 
 			var app = new CommandApp();

--- a/UnoCheck/Solutions/WinAppCliInstallSolution.cs
+++ b/UnoCheck/Solutions/WinAppCliInstallSolution.cs
@@ -1,0 +1,33 @@
+using DotNetCheck.Models;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotNetCheck.Solutions
+{
+	public class WinAppCliInstallSolution : Solution
+	{
+		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
+		{
+			await base.Implement(sharedState, cancellationToken);
+
+			ReportStatus("Installing WinApp CLI via winget...");
+
+			var result = new ShellProcessRunner(new(
+				"winget",
+				"install --id Microsoft.WinAppCli -e --accept-source-agreements --accept-package-agreements",
+				cancellationToken)
+			{ Verbose = true }).WaitForExit();
+
+			if (result.Success)
+			{
+				ReportStatus("WinApp CLI was installed.");
+			}
+			else
+			{
+				ReportStatus(
+					"Failed to install WinApp CLI via winget. " +
+					"Please install it manually with 'winget install Microsoft.WinAppCli' or 'npm install -g @microsoft/winappcli'.");
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a Windows-only `WinAppCliCheckup` that verifies the `winapp` CLI is installed when the manifest targets Windows (gated on `Check.VSWin`, matching `EdgeWebView2Checkup`).
- Detection runs `winapp --version` via `ShellProcessRunner` and reports the version on success.
- On failure, offers an auto-install `WinAppCliInstallSolution` that runs `winget install --id Microsoft.WinAppCli -e --accept-source-agreements --accept-package-agreements`, falling back to manual install instructions if winget fails.

Reference: [Introducing dotnet new templates for WinUI](https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/)

## Test plan
- [ ] On Windows without WinApp CLI installed, `uno-check` reports the check as failing and offers to install.
- [ ] Accepting the fix runs winget and installs `Microsoft.WinAppCli`; subsequent runs of `uno-check` report the check as OK with the installed version.
- [ ] On non-Windows platforms (macOS/Linux), the checkup is skipped (`IsPlatformSupported`).
- [ ] When the manifest has no `vswin` block, the checkup is skipped (`ShouldExamine`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)