### PR TITLE
feat: add dotnet-roots divergence and wasm targeting-pack alignment checkups

### DIFF
--- a/UnoCheck.Tests/DotNetRootsCheckupTests.cs
+++ b/UnoCheck.Tests/DotNetRootsCheckupTests.cs
@@ -35,16 +35,16 @@ namespace UnoCheck.Tests
 
 		private string CreateDotnetDir(string name, string exeName = "dotnet")
 		{
-			var dir = Path.Combine(_root, name);
+			var dir = Path.Join(_root, name);
 			Directory.CreateDirectory(dir);
-			File.WriteAllText(Path.Combine(dir, exeName), string.Empty);
+			File.WriteAllText(Path.Join(dir, exeName), string.Empty);
 			return dir;
 		}
 
 		[Fact]
 		public void ResolvePathDotnetRoot_FirstEntryCarryingExe_Wins()
 		{
-			var without = Path.Combine(_root, "no-dotnet-here");
+			var without = Path.Join(_root, "no-dotnet-here");
 			Directory.CreateDirectory(without);
 			var first = CreateDotnetDir("first");
 			var second = CreateDotnetDir("second");
@@ -95,7 +95,7 @@ namespace UnoCheck.Tests
 		[Fact]
 		public void ResolvePathDotnetRoot_NoMatch_ReturnsNull()
 		{
-			var without = Path.Combine(_root, "empty");
+			var without = Path.Join(_root, "empty");
 			Directory.CreateDirectory(without);
 
 			Assert.Null(DotNetRootsCheckup.ResolvePathDotnetRoot(without, "dotnet"));
@@ -106,8 +106,8 @@ namespace UnoCheck.Tests
 		{
 			var dir = CreateDotnetDir("rooted-exe");
 
-			// A rooted exe segment must not override the PATH entry in Path.Combine.
-			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(dir, Path.Combine(dir, "dotnet"));
+			// A rooted exe segment must not override the PATH entry when joined.
+			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(dir, Path.Join(dir, "dotnet"));
 
 			Assert.Equal(dir, resolved);
 		}
@@ -122,11 +122,11 @@ namespace UnoCheck.Tests
 
 			// PATH points at a bin dir whose dotnet is a two-hop symlink chain, mirroring
 			// /usr/bin/dotnet → /usr/lib/dotnet/dotnet.
-			var binDir = Path.Combine(_root, "bin");
+			var binDir = Path.Join(_root, "bin");
 			Directory.CreateDirectory(binDir);
-			var intermediate = Path.Combine(_root, "intermediate-link");
-			File.CreateSymbolicLink(intermediate, Path.Combine(realRoot, "dotnet"));
-			File.CreateSymbolicLink(Path.Combine(binDir, "dotnet"), intermediate);
+			var intermediate = Path.Join(_root, "intermediate-link");
+			File.CreateSymbolicLink(intermediate, Path.Join(realRoot, "dotnet"));
+			File.CreateSymbolicLink(Path.Join(binDir, "dotnet"), intermediate);
 
 			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(binDir, "dotnet");
 
@@ -136,7 +136,7 @@ namespace UnoCheck.Tests
 		[Fact]
 		public void ResolveLinks_RegularFile_ReturnsSamePath()
 		{
-			var file = Path.Combine(CreateDotnetDir("plain"), "dotnet");
+			var file = Path.Join(CreateDotnetDir("plain"), "dotnet");
 
 			Assert.Equal(file, DotNetRootsCheckup.ResolveLinks(file));
 		}
@@ -144,7 +144,7 @@ namespace UnoCheck.Tests
 		[Fact]
 		public void ResolveLinks_NonExistentFile_FallsBackToLiteralPath()
 		{
-			var file = Path.Combine(_root, "does-not-exist", "dotnet");
+			var file = Path.Join(_root, "does-not-exist", "dotnet");
 
 			Assert.Equal(file, DotNetRootsCheckup.ResolveLinks(file));
 		}
@@ -155,8 +155,8 @@ namespace UnoCheck.Tests
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 				return; // Creating symlinks on Windows requires elevation.
 
-			var link = Path.Combine(_root, "broken-link");
-			File.CreateSymbolicLink(link, Path.Combine(_root, "gone", "dotnet"));
+			var link = Path.Join(_root, "broken-link");
+			File.CreateSymbolicLink(link, Path.Join(_root, "gone", "dotnet"));
 
 			// Must not throw; either the (dangling) target or the literal path is acceptable.
 			Assert.NotNull(DotNetRootsCheckup.ResolveLinks(link));
@@ -165,7 +165,7 @@ namespace UnoCheck.Tests
 		[Fact]
 		public void NormalizeRoot_TrailingSeparators_AreTrimmed()
 		{
-			var expected = Path.Combine(_root, "sdk-root");
+			var expected = Path.Join(_root, "sdk-root");
 
 			Assert.Equal(expected, DotNetRootsCheckup.NormalizeRoot(expected + Path.DirectorySeparatorChar));
 		}
@@ -180,9 +180,9 @@ namespace UnoCheck.Tests
 		[Fact]
 		public void NormalizeRoot_RelativeSegments_AreResolved()
 		{
-			var expected = Path.Combine(_root, "sdk-root");
+			var expected = Path.Join(_root, "sdk-root");
 
-			var normalized = DotNetRootsCheckup.NormalizeRoot(Path.Combine(_root, "other", "..", "sdk-root"));
+			var normalized = DotNetRootsCheckup.NormalizeRoot(Path.Join(_root, "other", "..", "sdk-root"));
 
 			Assert.Equal(expected, normalized);
 		}

--- a/UnoCheck.Tests/DotNetRootsCheckupTests.cs
+++ b/UnoCheck.Tests/DotNetRootsCheckupTests.cs
@@ -93,6 +93,25 @@ namespace UnoCheck.Tests
 		}
 
 		[Fact]
+		public void ResolvePathDotnetRoot_EnvironmentVariableEntries_AreExpanded()
+		{
+			var dir = CreateDotnetDir("expanded");
+
+			Environment.SetEnvironmentVariable("UNO_CHECK_TEST_ROOT", dir);
+			try
+			{
+				// e.g. an unexpanded %ProgramFiles%\dotnet entry in a Windows PATH.
+				var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot("%UNO_CHECK_TEST_ROOT%", "dotnet");
+
+				Assert.Equal(dir, resolved);
+			}
+			finally
+			{
+				Environment.SetEnvironmentVariable("UNO_CHECK_TEST_ROOT", null);
+			}
+		}
+
+		[Fact]
 		public void ResolvePathDotnetRoot_NoMatch_ReturnsNull()
 		{
 			var without = Path.Join(_root, "empty");

--- a/UnoCheck.Tests/DotNetRootsCheckupTests.cs
+++ b/UnoCheck.Tests/DotNetRootsCheckupTests.cs
@@ -17,7 +17,7 @@ namespace UnoCheck.Tests
 
 		public DotNetRootsCheckupTests()
 		{
-			_root = Path.Combine(Path.GetTempPath(), "uno-check-tests", Guid.NewGuid().ToString("n"));
+			_root = Path.Join(Path.GetTempPath(), "uno-check-tests", Guid.NewGuid().ToString("n"));
 			Directory.CreateDirectory(_root);
 		}
 
@@ -185,6 +185,13 @@ namespace UnoCheck.Tests
 			var normalized = DotNetRootsCheckup.NormalizeRoot(Path.Combine(_root, "other", "..", "sdk-root"));
 
 			Assert.Equal(expected, normalized);
+		}
+
+		[Fact]
+		public void NormalizeRoot_MalformedPath_ReturnsNull()
+		{
+			// e.g. a broken DOTNET_ROOT value; must not throw out of the checkup.
+			Assert.Null(DotNetRootsCheckup.NormalizeRoot("bad\0path"));
 		}
 	}
 }

--- a/UnoCheck.Tests/DotNetRootsCheckupTests.cs
+++ b/UnoCheck.Tests/DotNetRootsCheckupTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using DotNetCheck.Checkups;
+using Xunit;
+
+namespace UnoCheck.Tests
+{
+	/// <summary>
+	/// Tests for the dotnet-roots divergence checkup internals (spec 001): PATH probing
+	/// (empty/quoted/malformed entries), symlink resolution (chains and broken links), and
+	/// root normalization.
+	/// </summary>
+	public class DotNetRootsCheckupTests : IDisposable
+	{
+		private readonly string _root;
+
+		public DotNetRootsCheckupTests()
+		{
+			_root = Path.Combine(Path.GetTempPath(), "uno-check-tests", Guid.NewGuid().ToString("n"));
+			Directory.CreateDirectory(_root);
+		}
+
+		public void Dispose()
+		{
+			try
+			{
+				Directory.Delete(_root, recursive: true);
+			}
+			catch
+			{
+				// Best effort cleanup of the temp fixture.
+			}
+		}
+
+		private string CreateDotnetDir(string name, string exeName = "dotnet")
+		{
+			var dir = Path.Combine(_root, name);
+			Directory.CreateDirectory(dir);
+			File.WriteAllText(Path.Combine(dir, exeName), string.Empty);
+			return dir;
+		}
+
+		[Fact]
+		public void ResolvePathDotnetRoot_FirstEntryCarryingExe_Wins()
+		{
+			var without = Path.Combine(_root, "no-dotnet-here");
+			Directory.CreateDirectory(without);
+			var first = CreateDotnetDir("first");
+			var second = CreateDotnetDir("second");
+
+			var pathValue = string.Join(Path.PathSeparator, without, first, second);
+
+			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(pathValue, "dotnet");
+
+			Assert.Equal(first, resolved);
+		}
+
+		[Fact]
+		public void ResolvePathDotnetRoot_EmptyAndWhitespaceEntries_AreSkipped()
+		{
+			var dir = CreateDotnetDir("real");
+
+			var pathValue = string.Join(Path.PathSeparator, "", "   ", dir, "");
+
+			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(pathValue, "dotnet");
+
+			Assert.Equal(dir, resolved);
+		}
+
+		[Fact]
+		public void ResolvePathDotnetRoot_QuotedEntries_AreUnquoted()
+		{
+			var dir = CreateDotnetDir("quoted");
+
+			var pathValue = $"\"{dir}\"";
+
+			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(pathValue, "dotnet");
+
+			Assert.Equal(dir, resolved);
+		}
+
+		[Fact]
+		public void ResolvePathDotnetRoot_MalformedEntries_AreSkipped()
+		{
+			var dir = CreateDotnetDir("after-junk");
+
+			var pathValue = string.Join(Path.PathSeparator, "\0junk", dir);
+
+			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(pathValue, "dotnet");
+
+			Assert.Equal(dir, resolved);
+		}
+
+		[Fact]
+		public void ResolvePathDotnetRoot_NoMatch_ReturnsNull()
+		{
+			var without = Path.Combine(_root, "empty");
+			Directory.CreateDirectory(without);
+
+			Assert.Null(DotNetRootsCheckup.ResolvePathDotnetRoot(without, "dotnet"));
+		}
+
+		[Fact]
+		public void ResolvePathDotnetRoot_RootedExeName_IsReducedToFileName()
+		{
+			var dir = CreateDotnetDir("rooted-exe");
+
+			// A rooted exe segment must not override the PATH entry in Path.Combine.
+			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(dir, Path.Combine(dir, "dotnet"));
+
+			Assert.Equal(dir, resolved);
+		}
+
+		[Fact]
+		public void ResolvePathDotnetRoot_SymlinkedExe_ResolvesToTargetRoot()
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				return; // Creating symlinks on Windows requires elevation.
+
+			var realRoot = CreateDotnetDir("real-root");
+
+			// PATH points at a bin dir whose dotnet is a two-hop symlink chain, mirroring
+			// /usr/bin/dotnet → /usr/lib/dotnet/dotnet.
+			var binDir = Path.Combine(_root, "bin");
+			Directory.CreateDirectory(binDir);
+			var intermediate = Path.Combine(_root, "intermediate-link");
+			File.CreateSymbolicLink(intermediate, Path.Combine(realRoot, "dotnet"));
+			File.CreateSymbolicLink(Path.Combine(binDir, "dotnet"), intermediate);
+
+			var resolved = DotNetRootsCheckup.ResolvePathDotnetRoot(binDir, "dotnet");
+
+			Assert.Equal(realRoot, resolved);
+		}
+
+		[Fact]
+		public void ResolveLinks_RegularFile_ReturnsSamePath()
+		{
+			var file = Path.Combine(CreateDotnetDir("plain"), "dotnet");
+
+			Assert.Equal(file, DotNetRootsCheckup.ResolveLinks(file));
+		}
+
+		[Fact]
+		public void ResolveLinks_NonExistentFile_FallsBackToLiteralPath()
+		{
+			var file = Path.Combine(_root, "does-not-exist", "dotnet");
+
+			Assert.Equal(file, DotNetRootsCheckup.ResolveLinks(file));
+		}
+
+		[Fact]
+		public void ResolveLinks_BrokenLink_FallsBackGracefully()
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				return; // Creating symlinks on Windows requires elevation.
+
+			var link = Path.Combine(_root, "broken-link");
+			File.CreateSymbolicLink(link, Path.Combine(_root, "gone", "dotnet"));
+
+			// Must not throw; either the (dangling) target or the literal path is acceptable.
+			Assert.NotNull(DotNetRootsCheckup.ResolveLinks(link));
+		}
+
+		[Fact]
+		public void NormalizeRoot_TrailingSeparators_AreTrimmed()
+		{
+			var expected = Path.Combine(_root, "sdk-root");
+
+			Assert.Equal(expected, DotNetRootsCheckup.NormalizeRoot(expected + Path.DirectorySeparatorChar));
+		}
+
+		[Fact]
+		public void NormalizeRoot_NullOrEmpty_ReturnsNull()
+		{
+			Assert.Null(DotNetRootsCheckup.NormalizeRoot(null));
+			Assert.Null(DotNetRootsCheckup.NormalizeRoot(string.Empty));
+		}
+
+		[Fact]
+		public void NormalizeRoot_RelativeSegments_AreResolved()
+		{
+			var expected = Path.Combine(_root, "sdk-root");
+
+			var normalized = DotNetRootsCheckup.NormalizeRoot(Path.Combine(_root, "other", "..", "sdk-root"));
+
+			Assert.Equal(expected, normalized);
+		}
+	}
+}

--- a/UnoCheck.Tests/DotNetTargetingPackAlignmentTests.cs
+++ b/UnoCheck.Tests/DotNetTargetingPackAlignmentTests.cs
@@ -16,7 +16,7 @@ namespace UnoCheck.Tests
 
 		public DotNetTargetingPackAlignmentTests()
 		{
-			_root = Path.Combine(Path.GetTempPath(), "uno-check-tests", Guid.NewGuid().ToString("n"));
+			_root = Path.Join(Path.GetTempPath(), "uno-check-tests", Guid.NewGuid().ToString("n"));
 			Directory.CreateDirectory(_root);
 		}
 
@@ -81,19 +81,19 @@ namespace UnoCheck.Tests
 		public void EnumerateMonoToolchainManifests_FlatAndVersionedLayouts_FindsBoth()
 		{
 			// Flat (older SDKs): sdk-manifests/<band>/<id>/WorkloadManifest.json
-			var flat = Path.Combine(_root, "sdk-manifests", "9.0.100", "microsoft.net.workload.mono.toolchain.current");
+			var flat = Path.Join(_root, "sdk-manifests", "9.0.100", "microsoft.net.workload.mono.toolchain.current");
 			Directory.CreateDirectory(flat);
-			File.WriteAllText(Path.Combine(flat, "WorkloadManifest.json"), MisalignedManifest);
+			File.WriteAllText(Path.Join(flat, "WorkloadManifest.json"), MisalignedManifest);
 
 			// Versioned (newer SDKs): sdk-manifests/<band>/<id>/<manifest-version>/WorkloadManifest.json
-			var versioned = Path.Combine(_root, "sdk-manifests", "10.0.100", "microsoft.net.workload.mono.toolchain.current", "10.0.105");
+			var versioned = Path.Join(_root, "sdk-manifests", "10.0.100", "microsoft.net.workload.mono.toolchain.current", "10.0.105");
 			Directory.CreateDirectory(versioned);
-			File.WriteAllText(Path.Combine(versioned, "WorkloadManifest.json"), MisalignedManifest);
+			File.WriteAllText(Path.Join(versioned, "WorkloadManifest.json"), MisalignedManifest);
 
 			// Unrelated manifest id: must not be picked up.
-			var other = Path.Combine(_root, "sdk-manifests", "10.0.100", "microsoft.net.sdk.android", "36.1.43");
+			var other = Path.Join(_root, "sdk-manifests", "10.0.100", "microsoft.net.sdk.android", "36.1.43");
 			Directory.CreateDirectory(other);
-			File.WriteAllText(Path.Combine(other, "WorkloadManifest.json"), MisalignedManifest);
+			File.WriteAllText(Path.Join(other, "WorkloadManifest.json"), MisalignedManifest);
 
 			var manifests = DotNetTargetingPackAlignmentCheckup.EnumerateMonoToolchainManifests(_root).ToList();
 
@@ -112,7 +112,7 @@ namespace UnoCheck.Tests
 		[Fact]
 		public void IsTargetingPackAvailable_InstalledInPacks_True()
 		{
-			Directory.CreateDirectory(Path.Combine(_root, "packs", "Microsoft.NETCore.App.Ref", "10.0.5"));
+			Directory.CreateDirectory(Path.Join(_root, "packs", "Microsoft.NETCore.App.Ref", "10.0.5"));
 
 			Assert.True(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "10.0.5"));
 		}
@@ -120,8 +120,8 @@ namespace UnoCheck.Tests
 		[Fact]
 		public void IsTargetingPackAvailable_InNugetCache_True()
 		{
-			var nugetRoot = Path.Combine(_root, "nuget-cache");
-			Directory.CreateDirectory(Path.Combine(nugetRoot, "microsoft.netcore.app.ref", "10.0.5"));
+			var nugetRoot = Path.Join(_root, "nuget-cache");
+			Directory.CreateDirectory(Path.Join(nugetRoot, "microsoft.netcore.app.ref", "10.0.5"));
 
 			var previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
 			try
@@ -139,23 +139,38 @@ namespace UnoCheck.Tests
 		[Fact]
 		public void IsTargetingPackAvailable_MalformedVersion_False()
 		{
-			// A parsed-manifest version that is empty or rooted must fail closed instead of
-			// probing outside the expected roots.
+			// A parsed-manifest version that is empty, rooted, or traversal-like must fail
+			// closed instead of probing outside the expected roots.
 			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, ""));
 			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "   "));
 			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, Path.GetTempPath()));
+			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, ".."));
+			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, ".." + Path.DirectorySeparatorChar + "escape"));
+			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "10.0.5" + Path.DirectorySeparatorChar + "nested"));
+			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "10.0.5" + Path.AltDirectorySeparatorChar + "nested"));
+		}
+
+		[Fact]
+		public void IsTargetingPackAvailable_TraversalVersion_DoesNotEscapeRoot()
+		{
+			// A pack directory reachable only by escaping the probed roots must not count.
+			Directory.CreateDirectory(Path.Join(_root, "outside", "10.0.5"));
+
+			var traversal = string.Join(Path.DirectorySeparatorChar.ToString(), "..", "..", "outside", "10.0.5");
+
+			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(Path.Join(_root, "packs-root"), traversal));
 		}
 
 		[Fact]
 		public void IsTargetingPackAvailable_NowhereToBeFound_False()
 		{
 			// Field case: manifest pins 10.0.5 while only 10.0.7 is installed.
-			Directory.CreateDirectory(Path.Combine(_root, "packs", "Microsoft.NETCore.App.Ref", "10.0.7"));
+			Directory.CreateDirectory(Path.Join(_root, "packs", "Microsoft.NETCore.App.Ref", "10.0.7"));
 
 			var previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
 			try
 			{
-				Environment.SetEnvironmentVariable("NUGET_PACKAGES", Path.Combine(_root, "empty-nuget-cache"));
+				Environment.SetEnvironmentVariable("NUGET_PACKAGES", Path.Join(_root, "empty-nuget-cache"));
 
 				Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "10.0.5"));
 			}

--- a/UnoCheck.Tests/DotNetTargetingPackAlignmentTests.cs
+++ b/UnoCheck.Tests/DotNetTargetingPackAlignmentTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.IO;
+using System.Linq;
+using DotNetCheck.Checkups;
+using Xunit;
+
+namespace UnoCheck.Tests
+{
+	/// <summary>
+	/// Tests for the targeting-pack alignment checkup internals (spec 001): manifest
+	/// enumeration across band layouts, pinned-version extraction, and pack probing.
+	/// </summary>
+	public class DotNetTargetingPackAlignmentTests : IDisposable
+	{
+		private readonly string _root;
+
+		public DotNetTargetingPackAlignmentTests()
+		{
+			_root = Path.Combine(Path.GetTempPath(), "uno-check-tests", Guid.NewGuid().ToString("n"));
+			Directory.CreateDirectory(_root);
+		}
+
+		public void Dispose()
+		{
+			try
+			{
+				Directory.Delete(_root, recursive: true);
+			}
+			catch
+			{
+				// Best effort cleanup of the temp fixture.
+			}
+		}
+
+		private const string MisalignedManifest = /*lang=json*/ """
+			{
+				"version": "10.0.105",
+				"depends-on": { "Microsoft.NET.Workload.Emscripten.Current": "10.0.105" },
+				"packs": {
+					"Microsoft.NETCore.App.Runtime.Mono.browser-wasm": {
+						"kind": "framework",
+						"version": "10.0.5"
+					},
+					"Microsoft.NET.Runtime.WebAssembly.Sdk": {
+						"kind": "sdk",
+						"version": "10.0.5"
+					}
+				}
+			}
+			""";
+
+		private const string ManifestWithoutBrowserWasm = /*lang=json*/ """
+			{
+				"version": "10.0.105",
+				"packs": {
+					"Microsoft.NET.Runtime.MonoAOTCompiler.Task": {
+						"kind": "sdk",
+						"version": "10.0.5"
+					}
+				}
+			}
+			""";
+
+		[Fact]
+		public void GetPinnedBrowserWasmRuntimeVersion_BrowserWasmPack_ReturnsVersion()
+		{
+			var version = DotNetTargetingPackAlignmentCheckup.GetPinnedBrowserWasmRuntimeVersion(MisalignedManifest);
+
+			Assert.Equal("10.0.5", version);
+		}
+
+		[Fact]
+		public void GetPinnedBrowserWasmRuntimeVersion_NoBrowserWasmPack_ReturnsNull()
+		{
+			var version = DotNetTargetingPackAlignmentCheckup.GetPinnedBrowserWasmRuntimeVersion(ManifestWithoutBrowserWasm);
+
+			Assert.Null(version);
+		}
+
+		[Fact]
+		public void EnumerateMonoToolchainManifests_FlatAndVersionedLayouts_FindsBoth()
+		{
+			// Flat (older SDKs): sdk-manifests/<band>/<id>/WorkloadManifest.json
+			var flat = Path.Combine(_root, "sdk-manifests", "9.0.100", "microsoft.net.workload.mono.toolchain.current");
+			Directory.CreateDirectory(flat);
+			File.WriteAllText(Path.Combine(flat, "WorkloadManifest.json"), MisalignedManifest);
+
+			// Versioned (newer SDKs): sdk-manifests/<band>/<id>/<manifest-version>/WorkloadManifest.json
+			var versioned = Path.Combine(_root, "sdk-manifests", "10.0.100", "microsoft.net.workload.mono.toolchain.current", "10.0.105");
+			Directory.CreateDirectory(versioned);
+			File.WriteAllText(Path.Combine(versioned, "WorkloadManifest.json"), MisalignedManifest);
+
+			// Unrelated manifest id: must not be picked up.
+			var other = Path.Combine(_root, "sdk-manifests", "10.0.100", "microsoft.net.sdk.android", "36.1.43");
+			Directory.CreateDirectory(other);
+			File.WriteAllText(Path.Combine(other, "WorkloadManifest.json"), MisalignedManifest);
+
+			var manifests = DotNetTargetingPackAlignmentCheckup.EnumerateMonoToolchainManifests(_root).ToList();
+
+			Assert.Equal(2, manifests.Count);
+			Assert.All(manifests, m => Assert.Contains("microsoft.net.workload.mono.toolchain.current", m));
+		}
+
+		[Fact]
+		public void EnumerateMonoToolchainManifests_NoManifestsFolder_Empty()
+		{
+			var manifests = DotNetTargetingPackAlignmentCheckup.EnumerateMonoToolchainManifests(_root);
+
+			Assert.Empty(manifests);
+		}
+
+		[Fact]
+		public void IsTargetingPackAvailable_InstalledInPacks_True()
+		{
+			Directory.CreateDirectory(Path.Combine(_root, "packs", "Microsoft.NETCore.App.Ref", "10.0.5"));
+
+			Assert.True(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "10.0.5"));
+		}
+
+		[Fact]
+		public void IsTargetingPackAvailable_InNugetCache_True()
+		{
+			var nugetRoot = Path.Combine(_root, "nuget-cache");
+			Directory.CreateDirectory(Path.Combine(nugetRoot, "microsoft.netcore.app.ref", "10.0.5"));
+
+			var previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+			try
+			{
+				Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetRoot);
+
+				Assert.True(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "10.0.5"));
+			}
+			finally
+			{
+				Environment.SetEnvironmentVariable("NUGET_PACKAGES", previous);
+			}
+		}
+
+		[Fact]
+		public void IsTargetingPackAvailable_NowhereToBeFound_False()
+		{
+			// Field case: manifest pins 10.0.5 while only 10.0.7 is installed.
+			Directory.CreateDirectory(Path.Combine(_root, "packs", "Microsoft.NETCore.App.Ref", "10.0.7"));
+
+			var previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+			try
+			{
+				Environment.SetEnvironmentVariable("NUGET_PACKAGES", Path.Combine(_root, "empty-nuget-cache"));
+
+				Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "10.0.5"));
+			}
+			finally
+			{
+				Environment.SetEnvironmentVariable("NUGET_PACKAGES", previous);
+			}
+		}
+	}
+}

--- a/UnoCheck.Tests/DotNetTargetingPackAlignmentTests.cs
+++ b/UnoCheck.Tests/DotNetTargetingPackAlignmentTests.cs
@@ -137,6 +137,16 @@ namespace UnoCheck.Tests
 		}
 
 		[Fact]
+		public void IsTargetingPackAvailable_MalformedVersion_False()
+		{
+			// A parsed-manifest version that is empty or rooted must fail closed instead of
+			// probing outside the expected roots.
+			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, ""));
+			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, "   "));
+			Assert.False(DotNetTargetingPackAlignmentCheckup.IsTargetingPackAvailable(_root, Path.GetTempPath()));
+		}
+
+		[Fact]
 		public void IsTargetingPackAvailable_NowhereToBeFound_False()
 		{
 			// Field case: manifest pins 10.0.5 while only 10.0.7 is installed.

--- a/UnoCheck.Tests/DotNetWorkloadUpdateSolutionTests.cs
+++ b/UnoCheck.Tests/DotNetWorkloadUpdateSolutionTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using DotNetCheck.Solutions;
+using Xunit;
+
+namespace UnoCheck.Tests
+{
+	/// <summary>
+	/// Tests for the workload-update failure message (spec 001): the exit code alone is
+	/// not actionable, so the message must carry the tail of the process output.
+	/// </summary>
+	public class DotNetWorkloadUpdateSolutionTests
+	{
+		[Fact]
+		public void BuildFailureMessage_NoOutput_ExitCodeOnly()
+		{
+			var message = DotNetWorkloadUpdateSolution.BuildFailureMessage("/roots/dotnet", 1, Array.Empty<string>());
+
+			Assert.Equal("'/roots/dotnet workload update' exited with code 1.", message);
+		}
+
+		[Fact]
+		public void BuildFailureMessage_WithOutput_CarriesTheActionableReason()
+		{
+			var message = DotNetWorkloadUpdateSolution.BuildFailureMessage(
+				"/roots/dotnet", 1, new[] { "Updating workloads...", "", "Workload update failed: access to the path is denied." });
+
+			Assert.Contains("exited with code 1", message);
+			Assert.Contains("access to the path is denied", message);
+			Assert.DoesNotContain(Environment.NewLine + Environment.NewLine, message); // blank lines dropped
+		}
+
+		[Fact]
+		public void BuildFailureMessage_LongOutput_KeepsOnlyTheTail()
+		{
+			var lines = Enumerable.Range(1, 50).Select(i => $"line {i}").ToArray();
+
+			var message = DotNetWorkloadUpdateSolution.BuildFailureMessage("/roots/dotnet", 1, lines);
+
+			Assert.DoesNotContain("line 40", message);
+			Assert.Contains("line 41", message);
+			Assert.Contains("line 50", message);
+		}
+	}
+}

--- a/UnoCheck/Checkups/DotNetRootsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetRootsCheckup.cs
@@ -78,7 +78,7 @@ namespace DotNetCheck.Checkups
 		/// probing order: <c>DOTNET_ROOT_&lt;ARCH&gt;</c> (net6+ hosts), then
 		/// <c>DOTNET_ROOT(x86)</c> for 32-bit processes, then <c>DOTNET_ROOT</c>.
 		/// </summary>
-		private static (string Variable, string Value) ResolveDotNetRootEnvironment()
+		internal static (string Variable, string Value) ResolveDotNetRootEnvironment()
 		{
 			var archVariable = $"DOTNET_ROOT_{RuntimeInformation.ProcessArchitecture.ToString().ToUpperInvariant()}";
 			var variables = new[] { archVariable, Environment.Is64BitProcess ? null : "DOTNET_ROOT(x86)", "DOTNET_ROOT" };
@@ -149,7 +149,9 @@ namespace DotNetCheck.Checkups
 				return file;
 
 			// readlink -f follows the whole chain (e.g. /usr/bin/dotnet → /usr/lib/dotnet/dotnet).
-			var result = new ShellProcessRunner(new ShellProcessRunnerOptions("readlink", $"-f \"{file}\"")).WaitForExit();
+			// Invoked directly (no system shell), so a path carrying quotes or metacharacters
+			// cannot be reinterpreted.
+			var result = new ShellProcessRunner(new ShellProcessRunnerOptions("readlink", $"-f \"{file}\"") { UseSystemShell = false }).WaitForExit();
 			var output = result.GetOutput()?.Trim();
 			return result.Success && !string.IsNullOrEmpty(output) ? output : file;
 #endif

--- a/UnoCheck/Checkups/DotNetRootsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetRootsCheckup.cs
@@ -104,8 +104,10 @@ namespace DotNetCheck.Checkups
 			if (string.IsNullOrEmpty(exeName))
 				return null;
 
+			// Windows PATH values can carry quoted entries and unexpanded %VAR% references
+			// (e.g. %ProgramFiles%\dotnet); both must be normalized before probing.
 			foreach (var entry in pathValue.Split(Path.PathSeparator)
-				.Select(entry => entry.Trim().Trim('"')) // Quoted entries occur in Windows PATH values.
+				.Select(entry => Environment.ExpandEnvironmentVariables(entry.Trim().Trim('"')))
 				.Where(entry => !string.IsNullOrWhiteSpace(entry)))
 			{
 				string candidate;

--- a/UnoCheck/Checkups/DotNetRootsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetRootsCheckup.cs
@@ -148,14 +148,31 @@ namespace DotNetCheck.Checkups
 			if (Util.IsWindows)
 				return file;
 
-			// readlink -f follows the whole chain (e.g. /usr/bin/dotnet → /usr/lib/dotnet/dotnet).
-			// Invoked directly (no system shell), so a path carrying quotes or metacharacters
-			// cannot be reinterpreted.
-			var result = new ShellProcessRunner(new ShellProcessRunnerOptions("readlink", $"-f \"{file}\"") { UseSystemShell = false }).WaitForExit();
-			var output = result.GetOutput()?.Trim();
-			return result.Success && !string.IsNullOrEmpty(output) ? output : file;
+			// realpath follows the whole chain (e.g. /usr/bin/dotnet → /usr/lib/dotnet/dotnet)
+			// and exists on both macOS and Linux; BSD readlink on older macOS lacks -f, so
+			// readlink is only the fallback. Both are invoked directly (no system shell).
+			return TryResolveLinkWithTool("realpath", $"\"{file}\"")
+				?? TryResolveLinkWithTool("readlink", $"-f \"{file}\"")
+				?? file;
 #endif
 		}
+
+#if !NET6_0_OR_GREATER
+		private static string TryResolveLinkWithTool(string tool, string args)
+		{
+			try
+			{
+				var result = new ShellProcessRunner(new ShellProcessRunnerOptions(tool, args) { UseSystemShell = false }).WaitForExit();
+				var output = result.GetOutput()?.Trim();
+				return result.Success && !string.IsNullOrEmpty(output) ? output : null;
+			}
+			catch (Exception)
+			{
+				// Tool missing or not runnable on this platform; the caller tries the next one.
+				return null;
+			}
+		}
+#endif
 
 		private static IEnumerable<string> EnumerateKnownRoots()
 		{

--- a/UnoCheck/Checkups/DotNetRootsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetRootsCheckup.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 using DotNetCheck.DotNet;
@@ -10,10 +12,10 @@ namespace DotNetCheck.Checkups
 {
 	/// <summary>
 	/// Surfaces multi-root .NET installations where the effective root — the one uno-check and
-	/// IDE/devserver tooling resolve (DOTNET_ROOT first) — differs from the root behind the
-	/// <c>dotnet</c> found on PATH. Workload and SDK maintenance commands typed in a terminal
-	/// hit the PATH root, so on such machines manual repairs silently land on the wrong
-	/// installation (see https://github.com/unoplatform/uno.check/issues/542).
+	/// IDE/devserver tooling resolve (DOTNET_ROOT-family variables first) — differs from the
+	/// root behind the <c>dotnet</c> found on PATH. Workload and SDK maintenance commands typed
+	/// in a terminal hit the PATH root, so on such machines manual repairs silently land on the
+	/// wrong installation (see https://github.com/unoplatform/uno.check/issues/542).
 	/// </summary>
 	public class DotNetRootsCheckup : Checkup
 	{
@@ -26,9 +28,17 @@ namespace DotNetCheck.Checkups
 
 		public override Task<DiagnosticResult> Examine(SharedState state)
 		{
-			var effectiveRoot = NormalizeRoot(new DotNetSdk(state).DotNetSdkLocation?.FullName);
+			var (environmentRootVariable, environmentRootValue) = ResolveDotNetRootEnvironment();
+			var environmentRoot = NormalizeRoot(environmentRootValue);
+
+			// The host gives the architecture-specific variables precedence over DOTNET_ROOT,
+			// while DotNetSdk only considers the latter — so when an arch-specific variable
+			// designates an existing root, it is the one tooling actually resolves.
+			var effectiveRoot = environmentRoot != null && Directory.Exists(environmentRoot)
+				? environmentRoot
+				: NormalizeRoot(new DotNetSdk(state).DotNetSdkLocation?.FullName);
+
 			var pathRoot = NormalizeRoot(ResolvePathDotnetRoot());
-			var environmentRoot = NormalizeRoot(Environment.GetEnvironmentVariable("DOTNET_ROOT"));
 
 			foreach (var root in EnumerateKnownRoots())
 			{
@@ -37,7 +47,7 @@ namespace DotNetCheck.Checkups
 
 			if (effectiveRoot != null)
 			{
-				ReportStatus($"Effective root (DOTNET_ROOT-first resolution, used by uno-check and IDE/devserver tooling): {effectiveRoot}", null);
+				ReportStatus($"Effective root ({environmentRootVariable ?? "DOTNET_ROOT"}-first resolution, used by uno-check and IDE/devserver tooling): {effectiveRoot}", null);
 			}
 
 			if (pathRoot != null)
@@ -50,32 +60,58 @@ namespace DotNetCheck.Checkups
 				return Task.FromResult(DiagnosticResult.Ok(this));
 			}
 
+			var effectiveDotnetCommandPath = Path.Join(effectiveRoot, DotNetSdk.DotNetExeName);
 			var message =
 				$"Two different .NET installations are in play: `dotnet` on PATH resolves to '{pathRoot}' " +
 				$"while the effective root is '{effectiveRoot}'" +
-				(environmentRoot != null ? $" (DOTNET_ROOT={environmentRoot})" : string.Empty) + ". " +
+				(environmentRoot != null ? $" ({environmentRootVariable}={environmentRoot})" : string.Empty) + ". " +
 				"IDE and devserver tooling (including Uno Hot Reload) use the effective root; terminal commands use the PATH one. " +
 				$"SDK and workload maintenance (e.g. `dotnet workload update`) must target the effective root explicitly: " +
-				$"'{Path.Combine(effectiveRoot, DotNetSdk.DotNetExeName)} workload update'. " +
+				$"'{effectiveDotnetCommandPath} workload update'. " +
 				"Alternatively align DOTNET_ROOT and PATH on a single installation.";
 
 			return Task.FromResult(new DiagnosticResult(Status.Warning, this, message));
 		}
 
-		private static string ResolvePathDotnetRoot()
+		/// <summary>
+		/// Resolves the DOTNET_ROOT-family variable the .NET host would use, following its
+		/// probing order: <c>DOTNET_ROOT_&lt;ARCH&gt;</c> (net6+ hosts), then
+		/// <c>DOTNET_ROOT(x86)</c> for 32-bit processes, then <c>DOTNET_ROOT</c>.
+		/// </summary>
+		private static (string Variable, string Value) ResolveDotNetRootEnvironment()
 		{
-			var exeName = DotNetSdk.DotNetExeName;
-			var pathValue = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+			var archVariable = $"DOTNET_ROOT_{RuntimeInformation.ProcessArchitecture.ToString().ToUpperInvariant()}";
+			var variables = new[] { archVariable, Environment.Is64BitProcess ? null : "DOTNET_ROOT(x86)", "DOTNET_ROOT" };
 
-			foreach (var entry in pathValue.Split(Path.PathSeparator))
+			foreach (var variable in variables.Where(v => v != null))
 			{
-				if (string.IsNullOrWhiteSpace(entry))
-					continue;
+				var value = Environment.GetEnvironmentVariable(variable);
+				if (!string.IsNullOrEmpty(value))
+					return (variable, value);
+			}
 
+			return (null, null);
+		}
+
+		private static string ResolvePathDotnetRoot()
+			=> ResolvePathDotnetRoot(Environment.GetEnvironmentVariable("PATH") ?? string.Empty, DotNetSdk.DotNetExeName);
+
+		internal static string ResolvePathDotnetRoot(string pathValue, string exeName)
+		{
+			// A bare file name is guaranteed here, so Path.Combine below cannot be
+			// short-circuited by a rooted second segment.
+			exeName = Path.GetFileName(exeName);
+			if (string.IsNullOrEmpty(exeName))
+				return null;
+
+			foreach (var entry in pathValue.Split(Path.PathSeparator)
+				.Select(entry => entry.Trim().Trim('"')) // Quoted entries occur in Windows PATH values.
+				.Where(entry => !string.IsNullOrWhiteSpace(entry)))
+			{
 				string candidate;
 				try
 				{
-					candidate = Path.Combine(entry.Trim(), exeName);
+					candidate = Path.Combine(entry, exeName);
 					if (!File.Exists(candidate))
 						continue;
 				}
@@ -91,7 +127,7 @@ namespace DotNetCheck.Checkups
 			return null;
 		}
 
-		private static string ResolveLinks(string file)
+		internal static string ResolveLinks(string file)
 		{
 #if NET6_0_OR_GREATER
 			try
@@ -100,9 +136,10 @@ namespace DotNetCheck.Checkups
 				if (resolved != null)
 					return resolved.FullName;
 			}
-			catch (IOException)
+			catch (Exception)
 			{
-				// Broken link or unsupported filesystem; fall back to the literal path.
+				// Broken link, restricted path or unsupported filesystem; fall back to the
+				// literal path rather than failing this informational checkup.
 			}
 
 			return file;
@@ -123,11 +160,11 @@ namespace DotNetCheck.Checkups
 
 			var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 			if (!string.IsNullOrEmpty(home))
-				candidates.Add(Path.Combine(home, ".dotnet"));
+				candidates.Add(Path.Join(home, ".dotnet"));
 
 			if (Util.IsWindows)
 			{
-				candidates.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet"));
+				candidates.Add(Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet"));
 			}
 			else if (Util.IsMac)
 			{
@@ -139,15 +176,14 @@ namespace DotNetCheck.Checkups
 				candidates.Add("/usr/share/dotnet");
 			}
 
-			foreach (var candidate in candidates)
+			// Only roots that actually carry SDKs matter for the divergence analysis.
+			foreach (var candidate in candidates.Where(candidate => Directory.Exists(Path.Join(candidate, "sdk"))))
 			{
-				// Only roots that actually carry SDKs matter for the divergence analysis.
-				if (Directory.Exists(Path.Combine(candidate, "sdk")))
-					yield return NormalizeRoot(candidate);
+				yield return NormalizeRoot(candidate);
 			}
 		}
 
-		private static string NormalizeRoot(string path)
+		internal static string NormalizeRoot(string path)
 			=> string.IsNullOrEmpty(path) ? null : Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
 		private static bool RootsEqual(string a, string b)

--- a/UnoCheck/Checkups/DotNetRootsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetRootsCheckup.cs
@@ -98,7 +98,7 @@ namespace DotNetCheck.Checkups
 
 		internal static string ResolvePathDotnetRoot(string pathValue, string exeName)
 		{
-			// A bare file name is guaranteed here, so Path.Combine below cannot be
+			// A bare file name is guaranteed here, so the join below cannot be
 			// short-circuited by a rooted second segment.
 			exeName = Path.GetFileName(exeName);
 			if (string.IsNullOrEmpty(exeName))
@@ -111,13 +111,14 @@ namespace DotNetCheck.Checkups
 				string candidate;
 				try
 				{
-					candidate = Path.Combine(entry, exeName);
+					candidate = Path.Join(entry, exeName);
 					if (!File.Exists(candidate))
 						continue;
 				}
-				catch (ArgumentException)
+				catch (Exception)
 				{
-					// Malformed PATH entry; skip it.
+					// Malformed PATH entry (invalid chars, too long, ...); skip it rather
+					// than letting it crash this informational checkup.
 					continue;
 				}
 
@@ -184,7 +185,21 @@ namespace DotNetCheck.Checkups
 		}
 
 		internal static string NormalizeRoot(string path)
-			=> string.IsNullOrEmpty(path) ? null : Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		{
+			if (string.IsNullOrEmpty(path))
+				return null;
+
+			try
+			{
+				return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+			}
+			catch (Exception)
+			{
+				// A malformed DOTNET_ROOT* (or other) value must not crash the checkup;
+				// treat it as no root at all.
+				return null;
+			}
+		}
 
 		private static bool RootsEqual(string a, string b)
 			=> string.Equals(a, b, Util.IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);

--- a/UnoCheck/Checkups/DotNetRootsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetRootsCheckup.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+using DotNetCheck.DotNet;
+using DotNetCheck.Models;
+
+namespace DotNetCheck.Checkups
+{
+	/// <summary>
+	/// Surfaces multi-root .NET installations where the effective root — the one uno-check and
+	/// IDE/devserver tooling resolve (DOTNET_ROOT first) — differs from the root behind the
+	/// <c>dotnet</c> found on PATH. Workload and SDK maintenance commands typed in a terminal
+	/// hit the PATH root, so on such machines manual repairs silently land on the wrong
+	/// installation (see https://github.com/unoplatform/uno.check/issues/542).
+	/// </summary>
+	public class DotNetRootsCheckup : Checkup
+	{
+		public override string Id => "dotnetroots";
+
+		public override string Title => ".NET installation roots";
+
+		public override IEnumerable<CheckupDependency> DeclareDependencies(IEnumerable<string> checkupIds)
+			=> new[] { new CheckupDependency("dotnet") };
+
+		public override Task<DiagnosticResult> Examine(SharedState state)
+		{
+			var effectiveRoot = NormalizeRoot(new DotNetSdk(state).DotNetSdkLocation?.FullName);
+			var pathRoot = NormalizeRoot(ResolvePathDotnetRoot());
+			var environmentRoot = NormalizeRoot(Environment.GetEnvironmentVariable("DOTNET_ROOT"));
+
+			foreach (var root in EnumerateKnownRoots())
+			{
+				ReportStatus($"Found .NET root: {root}", null);
+			}
+
+			if (effectiveRoot != null)
+			{
+				ReportStatus($"Effective root (DOTNET_ROOT-first resolution, used by uno-check and IDE/devserver tooling): {effectiveRoot}", null);
+			}
+
+			if (pathRoot != null)
+			{
+				ReportStatus($"PATH root (used by terminal 'dotnet' commands): {pathRoot}", null);
+			}
+
+			if (effectiveRoot == null || pathRoot == null || RootsEqual(effectiveRoot, pathRoot))
+			{
+				return Task.FromResult(DiagnosticResult.Ok(this));
+			}
+
+			var message =
+				$"Two different .NET installations are in play: `dotnet` on PATH resolves to '{pathRoot}' " +
+				$"while the effective root is '{effectiveRoot}'" +
+				(environmentRoot != null ? $" (DOTNET_ROOT={environmentRoot})" : string.Empty) + ". " +
+				"IDE and devserver tooling (including Uno Hot Reload) use the effective root; terminal commands use the PATH one. " +
+				$"SDK and workload maintenance (e.g. `dotnet workload update`) must target the effective root explicitly: " +
+				$"'{Path.Combine(effectiveRoot, DotNetSdk.DotNetExeName)} workload update'. " +
+				"Alternatively align DOTNET_ROOT and PATH on a single installation.";
+
+			return Task.FromResult(new DiagnosticResult(Status.Warning, this, message));
+		}
+
+		private static string ResolvePathDotnetRoot()
+		{
+			var exeName = DotNetSdk.DotNetExeName;
+			var pathValue = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+
+			foreach (var entry in pathValue.Split(Path.PathSeparator))
+			{
+				if (string.IsNullOrWhiteSpace(entry))
+					continue;
+
+				string candidate;
+				try
+				{
+					candidate = Path.Combine(entry.Trim(), exeName);
+					if (!File.Exists(candidate))
+						continue;
+				}
+				catch (ArgumentException)
+				{
+					// Malformed PATH entry; skip it.
+					continue;
+				}
+
+				return Path.GetDirectoryName(ResolveLinks(candidate));
+			}
+
+			return null;
+		}
+
+		private static string ResolveLinks(string file)
+		{
+#if NET6_0_OR_GREATER
+			try
+			{
+				var resolved = File.ResolveLinkTarget(file, returnFinalTarget: true);
+				if (resolved != null)
+					return resolved.FullName;
+			}
+			catch (IOException)
+			{
+				// Broken link or unsupported filesystem; fall back to the literal path.
+			}
+
+			return file;
+#else
+			if (Util.IsWindows)
+				return file;
+
+			// readlink -f follows the whole chain (e.g. /usr/bin/dotnet → /usr/lib/dotnet/dotnet).
+			var result = new ShellProcessRunner(new ShellProcessRunnerOptions("readlink", $"-f \"{file}\"")).WaitForExit();
+			var output = result.GetOutput()?.Trim();
+			return result.Success && !string.IsNullOrEmpty(output) ? output : file;
+#endif
+		}
+
+		private static IEnumerable<string> EnumerateKnownRoots()
+		{
+			var candidates = new List<string>();
+
+			var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			if (!string.IsNullOrEmpty(home))
+				candidates.Add(Path.Combine(home, ".dotnet"));
+
+			if (Util.IsWindows)
+			{
+				candidates.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet"));
+			}
+			else if (Util.IsMac)
+			{
+				candidates.Add("/usr/local/share/dotnet");
+			}
+			else
+			{
+				candidates.Add("/usr/lib/dotnet");
+				candidates.Add("/usr/share/dotnet");
+			}
+
+			foreach (var candidate in candidates)
+			{
+				// Only roots that actually carry SDKs matter for the divergence analysis.
+				if (Directory.Exists(Path.Combine(candidate, "sdk")))
+					yield return NormalizeRoot(candidate);
+			}
+		}
+
+		private static string NormalizeRoot(string path)
+			=> string.IsNullOrEmpty(path) ? null : Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+		private static bool RootsEqual(string a, string b)
+			=> string.Equals(a, b, Util.IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+	}
+}

--- a/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
+++ b/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 using DotNetCheck.DotNet;
@@ -109,21 +110,19 @@ namespace DotNetCheck.Checkups
 			if (!Directory.Exists(manifestsRoot))
 				yield break;
 
-			foreach (var band in Directory.EnumerateDirectories(manifestsRoot))
+			foreach (var manifestDir in SafeEnumerateDirectories(manifestsRoot)
+				.Select(band => Path.Combine(band, MonoToolchainManifestId))
+				.Where(Directory.Exists))
 			{
-				var manifestDir = Path.Combine(band, MonoToolchainManifestId);
-				if (!Directory.Exists(manifestDir))
-					continue;
-
 				var flat = Path.Combine(manifestDir, "WorkloadManifest.json");
 				if (File.Exists(flat))
 					yield return flat;
 
-				foreach (var versionDir in Directory.EnumerateDirectories(manifestDir))
+				foreach (var versioned in SafeEnumerateDirectories(manifestDir)
+					.Select(versionDir => Path.Combine(versionDir, "WorkloadManifest.json"))
+					.Where(File.Exists))
 				{
-					var versioned = Path.Combine(versionDir, "WorkloadManifest.json");
-					if (File.Exists(versioned))
-						yield return versioned;
+					yield return versioned;
 				}
 			}
 		}
@@ -140,13 +139,10 @@ namespace DotNetCheck.Checkups
 			if (manifest["packs"] is not JObject packs)
 				return null;
 
-			foreach (var pack in packs.Properties())
-			{
-				if (pack.Name.StartsWith(BrowserWasmRuntimePackPrefix, StringComparison.OrdinalIgnoreCase))
-					return pack.Value?["version"]?.ToString();
-			}
-
-			return null;
+			return packs.Properties()
+				.Where(pack => pack.Name.StartsWith(BrowserWasmRuntimePackPrefix, StringComparison.OrdinalIgnoreCase))
+				.Select(pack => pack.Value?["version"]?.ToString())
+				.FirstOrDefault();
 		}
 
 		internal static bool IsTargetingPackAvailable(string dotnetRoot, string version)
@@ -169,15 +165,38 @@ namespace DotNetCheck.Checkups
 
 		private static string DescribeInstalledTargetingPacks(string dotnetRoot)
 		{
-			var packsDir = Path.Combine(dotnetRoot, "packs", TargetingPackName);
-			if (!Directory.Exists(packsDir))
-				return "none";
+			try
+			{
+				var packsDir = Path.Combine(dotnetRoot, "packs", TargetingPackName);
+				if (!Directory.Exists(packsDir))
+					return "none";
 
-			var versions = new List<string>();
-			foreach (var dir in Directory.EnumerateDirectories(packsDir))
-				versions.Add(Path.GetFileName(dir));
+				var versions = Directory.EnumerateDirectories(packsDir).Select(Path.GetFileName).ToList();
 
-			return versions.Count == 0 ? "none" : string.Join(", ", versions);
+				return versions.Count == 0 ? "none" : string.Join(", ", versions);
+			}
+			catch (Exception)
+			{
+				// This only feeds the diagnostic message; an unreadable packs folder must not
+				// crash the checkup while it is reporting a failure.
+				return "unknown";
+			}
+		}
+
+		/// <summary>
+		/// Enumerates sub-directories, treating unreadable directories (ACLs, transient IO)
+		/// as empty so a filesystem hiccup does not crash the whole checkup.
+		/// </summary>
+		private static string[] SafeEnumerateDirectories(string path)
+		{
+			try
+			{
+				return Directory.GetDirectories(path);
+			}
+			catch (Exception)
+			{
+				return Array.Empty<string>();
+			}
 		}
 	}
 }

--- a/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
+++ b/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
@@ -106,20 +106,20 @@ namespace DotNetCheck.Checkups
 		/// </summary>
 		internal static IEnumerable<string> EnumerateMonoToolchainManifests(string dotnetRoot)
 		{
-			var manifestsRoot = Path.Combine(dotnetRoot, "sdk-manifests");
+			var manifestsRoot = Path.Join(dotnetRoot, "sdk-manifests");
 			if (!Directory.Exists(manifestsRoot))
 				yield break;
 
 			foreach (var manifestDir in SafeEnumerateDirectories(manifestsRoot)
-				.Select(band => Path.Combine(band, MonoToolchainManifestId))
+				.Select(band => Path.Join(band, MonoToolchainManifestId))
 				.Where(Directory.Exists))
 			{
-				var flat = Path.Combine(manifestDir, "WorkloadManifest.json");
+				var flat = Path.Join(manifestDir, "WorkloadManifest.json");
 				if (File.Exists(flat))
 					yield return flat;
 
 				foreach (var versioned in SafeEnumerateDirectories(manifestDir)
-					.Select(versionDir => Path.Combine(versionDir, "WorkloadManifest.json"))
+					.Select(versionDir => Path.Join(versionDir, "WorkloadManifest.json"))
 					.Where(File.Exists))
 				{
 					yield return versioned;
@@ -147,7 +147,12 @@ namespace DotNetCheck.Checkups
 
 		internal static bool IsTargetingPackAvailable(string dotnetRoot, string version)
 		{
-			if (Directory.Exists(Path.Combine(dotnetRoot, "packs", TargetingPackName, version)))
+			// The version comes from a parsed manifest: a malformed (empty or rooted) value
+			// must not be probed as if it designated a pack under the roots below.
+			if (string.IsNullOrWhiteSpace(version) || Path.IsPathRooted(version))
+				return false;
+
+			if (Directory.Exists(Path.Join(dotnetRoot, "packs", TargetingPackName, version)))
 				return true;
 
 			// A prior restore may have materialized the PackageDownload into the NuGet cache,
@@ -156,18 +161,18 @@ namespace DotNetCheck.Checkups
 			if (string.IsNullOrEmpty(nugetRoot))
 			{
 				var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-				nugetRoot = string.IsNullOrEmpty(home) ? null : Path.Combine(home, ".nuget", "packages");
+				nugetRoot = string.IsNullOrEmpty(home) ? null : Path.Join(home, ".nuget", "packages");
 			}
 
 			return nugetRoot != null
-				&& Directory.Exists(Path.Combine(nugetRoot, TargetingPackName.ToLowerInvariant(), version));
+				&& Directory.Exists(Path.Join(nugetRoot, TargetingPackName.ToLowerInvariant(), version));
 		}
 
 		private static string DescribeInstalledTargetingPacks(string dotnetRoot)
 		{
 			try
 			{
-				var packsDir = Path.Combine(dotnetRoot, "packs", TargetingPackName);
+				var packsDir = Path.Join(dotnetRoot, "packs", TargetingPackName);
 				if (!Directory.Exists(packsDir))
 					return "none";
 

--- a/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
+++ b/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
@@ -147,10 +147,16 @@ namespace DotNetCheck.Checkups
 
 		internal static bool IsTargetingPackAvailable(string dotnetRoot, string version)
 		{
-			// The version comes from a parsed manifest: a malformed (empty or rooted) value
-			// must not be probed as if it designated a pack under the roots below.
-			if (string.IsNullOrWhiteSpace(version) || Path.IsPathRooted(version))
+			// The version comes from a parsed manifest: it must stay a single child segment
+			// under the roots below, so reject anything empty, rooted, or carrying
+			// separators/traversal sequences instead of probing outside those roots.
+			if (string.IsNullOrWhiteSpace(version)
+				|| Path.IsPathRooted(version)
+				|| version.Contains("..")
+				|| version.IndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }) >= 0)
+			{
 				return false;
+			}
 
 			if (Directory.Exists(Path.Join(dotnetRoot, "packs", TargetingPackName, version)))
 				return true;

--- a/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
+++ b/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
@@ -40,8 +40,7 @@ namespace DotNetCheck.Checkups
 
 		public override Task<DiagnosticResult> Examine(SharedState state)
 		{
-			var sdk = new DotNetSdk(state);
-			var root = sdk.DotNetSdkLocation;
+			var root = ResolveEffectiveRoot(state);
 
 			if (root == null || !root.Exists)
 			{
@@ -90,12 +89,30 @@ namespace DotNetCheck.Checkups
 				"(Uno Hot Reload) silently produce compilations without any .NET framework reference, blocking hot reload " +
 				"for WebAssembly. Running 'dotnet workload update' on this .NET root realigns the manifests with the SDK.";
 
+			// The fix must drive the muxer of the root that was examined, not whatever
+			// another resolution would pick.
+			var dotnetExePath = Path.Join(root.FullName, DotNetSdk.DotNetExeName);
 			var suggestion = new Suggestion(
 				"Update the workload manifests to match the installed SDK",
-				$"Runs '{sdk.DotNetExeLocation.FullName} workload update' (root: {root.FullName}).",
-				new DotNetWorkloadUpdateSolution(sdk.DotNetExeLocation.FullName));
+				$"Runs '{dotnetExePath} workload update' (root: {root.FullName}).",
+				new DotNetWorkloadUpdateSolution(dotnetExePath));
 
 			return Task.FromResult(new DiagnosticResult(Status.Error, this, message, suggestion));
+		}
+
+		/// <summary>
+		/// Resolves the effective root with the same DOTNET_ROOT-family host probing order as
+		/// <see cref="DotNetRootsCheckup"/>: an arch-specific variable outranks DOTNET_ROOT —
+		/// which is all <see cref="DotNetSdk"/> considers — so alignment is examined (and the
+		/// fix muxer chosen) on the installation tooling actually resolves.
+		/// </summary>
+		private static DirectoryInfo ResolveEffectiveRoot(SharedState state)
+		{
+			var (_, environmentRoot) = DotNetRootsCheckup.ResolveDotNetRootEnvironment();
+
+			return environmentRoot != null && Directory.Exists(environmentRoot)
+				? new DirectoryInfo(environmentRoot)
+				: new DotNetSdk(state).DotNetSdkLocation;
 		}
 
 		/// <summary>

--- a/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
+++ b/UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+using DotNetCheck.DotNet;
+using DotNetCheck.Models;
+using DotNetCheck.Solutions;
+using Newtonsoft.Json.Linq;
+
+namespace DotNetCheck.Checkups
+{
+	/// <summary>
+	/// Verifies that the <c>Microsoft.NETCore.App</c> version pinned for browser-wasm by the
+	/// installed mono-toolchain workload manifests has its targeting pack available — either
+	/// under the effective root's <c>packs/</c> folder or in the NuGet cache (materialized by a
+	/// restore-time <c>PackageDownload</c>). When it is missing, regular builds still work
+	/// (restore downloads the pack) but restore-less design-time builds — Uno Hot Reload —
+	/// silently produce compilations without any framework reference (the .NET SDK deliberately
+	/// emits no error under <c>DesignTimeBuild=true</c>). See
+	/// https://github.com/unoplatform/uno.check/issues/542 and
+	/// https://github.com/unoplatform/uno/issues/23780.
+	/// </summary>
+	public class DotNetTargetingPackAlignmentCheckup : Checkup
+	{
+		private const string MonoToolchainManifestId = "microsoft.net.workload.mono.toolchain.current";
+		private const string BrowserWasmRuntimePackPrefix = "Microsoft.NETCore.App.Runtime.Mono.browser-wasm";
+		private const string TargetingPackName = "Microsoft.NETCore.App.Ref";
+
+		public override string Id => "dotnettargetingpacks";
+
+		public override string Title => ".NET wasm targeting-pack alignment";
+
+		public override IEnumerable<CheckupDependency> DeclareDependencies(IEnumerable<string> checkupIds)
+			=> new[] { new CheckupDependency("dotnet") };
+
+		public override TargetPlatform GetApplicableTargets(Manifest.Manifest manifest)
+			=> TargetPlatform.WebAssembly;
+
+		public override Task<DiagnosticResult> Examine(SharedState state)
+		{
+			var sdk = new DotNetSdk(state);
+			var root = sdk.DotNetSdkLocation;
+
+			if (root == null || !root.Exists)
+			{
+				// The dotnet checkup (declared dependency) reports the missing SDK itself.
+				return Task.FromResult(DiagnosticResult.Ok(this));
+			}
+
+			var misaligned = new List<(string ManifestPath, string PinnedVersion)>();
+
+			foreach (var manifestFile in EnumerateMonoToolchainManifests(root.FullName))
+			{
+				string pinnedVersion;
+				try
+				{
+					pinnedVersion = GetPinnedBrowserWasmRuntimeVersion(File.ReadAllText(manifestFile));
+				}
+				catch (Exception ex)
+				{
+					ReportStatus($"Could not read workload manifest '{manifestFile}': {ex.Message}", null);
+					continue;
+				}
+
+				if (string.IsNullOrEmpty(pinnedVersion))
+					continue;
+
+				if (IsTargetingPackAvailable(root.FullName, pinnedVersion))
+				{
+					ReportStatus($"Manifest '{manifestFile}' pins {TargetingPackName} {pinnedVersion}: available.", null);
+					continue;
+				}
+
+				misaligned.Add((manifestFile, pinnedVersion));
+			}
+
+			if (misaligned.Count == 0)
+			{
+				return Task.FromResult(DiagnosticResult.Ok(this));
+			}
+
+			var installedPacks = DescribeInstalledTargetingPacks(root.FullName);
+			var details = string.Join(" ", misaligned.ConvertAll(m =>
+				$"The workload manifest '{m.ManifestPath}' pins the browser-wasm runtime to {TargetingPackName} {m.PinnedVersion}, which is neither installed (installed: {installedPacks}) nor in the NuGet cache."));
+
+			var message =
+				$"{details} Regular builds survive by downloading the pack at restore, but restore-less design-time builds " +
+				"(Uno Hot Reload) silently produce compilations without any .NET framework reference, blocking hot reload " +
+				"for WebAssembly. Running 'dotnet workload update' on this .NET root realigns the manifests with the SDK.";
+
+			var suggestion = new Suggestion(
+				"Update the workload manifests to match the installed SDK",
+				$"Runs '{sdk.DotNetExeLocation.FullName} workload update' (root: {root.FullName}).",
+				new DotNetWorkloadUpdateSolution(sdk.DotNetExeLocation.FullName));
+
+			return Task.FromResult(new DiagnosticResult(Status.Error, this, message, suggestion));
+		}
+
+		/// <summary>
+		/// Enumerates the mono-toolchain <c>WorkloadManifest.json</c> files across the SDK bands
+		/// of <paramref name="dotnetRoot"/>, supporting both layouts: the flat one
+		/// (<c>sdk-manifests/&lt;band&gt;/&lt;id&gt;/WorkloadManifest.json</c>) and the versioned one
+		/// (<c>sdk-manifests/&lt;band&gt;/&lt;id&gt;/&lt;manifest-version&gt;/WorkloadManifest.json</c>).
+		/// </summary>
+		internal static IEnumerable<string> EnumerateMonoToolchainManifests(string dotnetRoot)
+		{
+			var manifestsRoot = Path.Combine(dotnetRoot, "sdk-manifests");
+			if (!Directory.Exists(manifestsRoot))
+				yield break;
+
+			foreach (var band in Directory.EnumerateDirectories(manifestsRoot))
+			{
+				var manifestDir = Path.Combine(band, MonoToolchainManifestId);
+				if (!Directory.Exists(manifestDir))
+					continue;
+
+				var flat = Path.Combine(manifestDir, "WorkloadManifest.json");
+				if (File.Exists(flat))
+					yield return flat;
+
+				foreach (var versionDir in Directory.EnumerateDirectories(manifestDir))
+				{
+					var versioned = Path.Combine(versionDir, "WorkloadManifest.json");
+					if (File.Exists(versioned))
+						yield return versioned;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Extracts the <c>Microsoft.NETCore.App</c> version the manifest pins for browser-wasm,
+		/// from the version of its <c>Microsoft.NETCore.App.Runtime.Mono.browser-wasm</c> pack.
+		/// Returns <see langword="null"/> when the manifest carries no such pack.
+		/// </summary>
+		internal static string GetPinnedBrowserWasmRuntimeVersion(string manifestJson)
+		{
+			var manifest = JObject.Parse(manifestJson);
+
+			if (manifest["packs"] is not JObject packs)
+				return null;
+
+			foreach (var pack in packs.Properties())
+			{
+				if (pack.Name.StartsWith(BrowserWasmRuntimePackPrefix, StringComparison.OrdinalIgnoreCase))
+					return pack.Value?["version"]?.ToString();
+			}
+
+			return null;
+		}
+
+		internal static bool IsTargetingPackAvailable(string dotnetRoot, string version)
+		{
+			if (Directory.Exists(Path.Combine(dotnetRoot, "packs", TargetingPackName, version)))
+				return true;
+
+			// A prior restore may have materialized the PackageDownload into the NuGet cache,
+			// which design-time builds resolve from as well.
+			var nugetRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+			if (string.IsNullOrEmpty(nugetRoot))
+			{
+				var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+				nugetRoot = string.IsNullOrEmpty(home) ? null : Path.Combine(home, ".nuget", "packages");
+			}
+
+			return nugetRoot != null
+				&& Directory.Exists(Path.Combine(nugetRoot, TargetingPackName.ToLowerInvariant(), version));
+		}
+
+		private static string DescribeInstalledTargetingPacks(string dotnetRoot)
+		{
+			var packsDir = Path.Combine(dotnetRoot, "packs", TargetingPackName);
+			if (!Directory.Exists(packsDir))
+				return "none";
+
+			var versions = new List<string>();
+			foreach (var dir in Directory.EnumerateDirectories(packsDir))
+				versions.Add(Path.GetFileName(dir));
+
+			return versions.Count == 0 ? "none" : string.Join(", ", versions);
+		}
+	}
+}

--- a/UnoCheck/Program.cs
+++ b/UnoCheck/Program.cs
@@ -52,7 +52,9 @@ namespace DotNetCheck
 				new HyperVCheckup(),
 				new DotNetNewUnoTemplatesCheckup(),
 				new UnoSdkCheckup(),
-				new EdgeWebView2Checkup()
+				new EdgeWebView2Checkup(),
+				new DotNetRootsCheckup(),
+				new DotNetTargetingPackAlignmentCheckup()
 			);
 
 			var app = new CommandApp();

--- a/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
+++ b/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using DotNetCheck.Models;
@@ -36,7 +37,9 @@ namespace DotNetCheck.Solutions
 			}
 			else
 			{
-				ReportStatus($"'workload update' exited with code {result.ExitCode}.");
+				// Throwing lets the fix runner surface the remediation failure instead of
+				// reporting "Fix applied" for an update that did not happen.
+				throw new Exception($"'{_dotnetExePath} workload update' exited with code {result.ExitCode}.");
 			}
 		}
 	}

--- a/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
+++ b/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -42,8 +44,22 @@ namespace DotNetCheck.Solutions
 			{
 				// Throwing lets the fix runner surface the remediation failure instead of
 				// reporting "Fix applied" for an update that did not happen.
-				throw new Exception($"'{_dotnetExePath} workload update' exited with code {result.ExitCode}.");
+				throw new Exception(BuildFailureMessage(_dotnetExePath, result.ExitCode, result.StandardOutput.Concat(result.StandardError)));
 			}
+		}
+
+		/// <summary>
+		/// The actionable reason (permissions, corrupted manifests, missing SDK band, ...)
+		/// lives in the process output, so the failure message carries its tail alongside
+		/// the exit code.
+		/// </summary>
+		internal static string BuildFailureMessage(string dotnetExePath, int exitCode, IEnumerable<string> outputLines)
+		{
+			var tail = string.Join(Environment.NewLine,
+				outputLines.Where(line => !string.IsNullOrWhiteSpace(line)).TakeLast(10));
+
+			return $"'{dotnetExePath} workload update' exited with code {exitCode}."
+				+ (tail.Length == 0 ? string.Empty : $" Output:{Environment.NewLine}{tail}");
 		}
 	}
 }

--- a/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
+++ b/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
@@ -27,8 +27,11 @@ namespace DotNetCheck.Solutions
 
 			ReportStatus($"Running '{_dotnetExePath} workload update'...");
 
+			// The muxer path is fully resolved, so invoke it directly instead of going
+			// through the system shell (temp script + zsh/bash on unix): no quoting or
+			// injection surface, same output capture.
 			var result = await Task.Run(
-				() => new ShellProcessRunner(new ShellProcessRunnerOptions(_dotnetExePath, "workload update", cancellationToken) { Verbose = true }).WaitForExit(),
+				() => new ShellProcessRunner(new ShellProcessRunnerOptions(_dotnetExePath, "workload update", cancellationToken) { Verbose = true, UseSystemShell = false }).WaitForExit(),
 				cancellationToken);
 
 			if (result.Success)

--- a/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
+++ b/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using DotNetCheck.Models;
+
+namespace DotNetCheck.Solutions
+{
+	/// <summary>
+	/// Runs <c>dotnet workload update</c> with an explicit muxer so the update targets the
+	/// intended .NET root — on multi-root machines a bare <c>dotnet</c> would hit whatever PATH
+	/// resolves first, which is precisely the failure mode this solution repairs (see
+	/// <see cref="Checkups.DotNetTargetingPackAlignmentCheckup"/>).
+	/// </summary>
+	public class DotNetWorkloadUpdateSolution : Solution
+	{
+		private readonly string _dotnetExePath;
+
+		public DotNetWorkloadUpdateSolution(string dotnetExePath)
+		{
+			_dotnetExePath = dotnetExePath;
+		}
+
+		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
+		{
+			await base.Implement(sharedState, cancellationToken);
+
+			ReportStatus($"Running '{_dotnetExePath} workload update'...");
+
+			var result = await Task.Run(
+				() => new ShellProcessRunner(new ShellProcessRunnerOptions(_dotnetExePath, "workload update", cancellationToken) { Verbose = true }).WaitForExit(),
+				cancellationToken);
+
+			if (result.Success)
+			{
+				ReportStatus("Workload manifests updated.");
+			}
+			else
+			{
+				ReportStatus($"'workload update' exited with code {result.ExitCode}.");
+			}
+		}
+	}
+}

--- a/specs/001-dotnet-roots-targeting-pack-alignment/spec.md
+++ b/specs/001-dotnet-roots-targeting-pack-alignment/spec.md
@@ -1,0 +1,148 @@
+# uno-check: Dotnet-Roots Divergence & Targeting-Pack Alignment Checkups
+
+Issue: [unoplatform/uno.check#542](https://github.com/unoplatform/uno.check/issues/542)
+Companion (hot-reload detection/recovery in the devserver): [unoplatform/uno#23780](https://github.com/unoplatform/uno/issues/23780)
+
+## Overview & Objectives
+
+Field case (Ubuntu 24.04): Uno Hot Reload silently broken for `net10.0-browserwasm` while
+regular builds work. Two environmental defects combined:
+
+1. **Two dotnet roots with diverging resolution** — `PATH` resolves `/usr/bin/dotnet`
+   (apt root, SDK 10.0.201, wasm manifest 10.0.108) while `DOTNET_ROOT=~/.dotnet`
+   (dotnet-install root, SDK 10.0.203, wasm manifest **10.0.105**). Tooling that resolves
+   through `DOTNET_ROOT`/hostfxr (devserver → Roslyn BuildHost) uses a different SDK than
+   the user's terminal. The user ran `dotnet workload uninstall/install wasm-tools` to fix
+   the issue — on the `PATH` dotnet, i.e. **on the wrong root**, with no effect.
+2. **Stale mono-toolchain workload manifest vs installed packs** — in `~/.dotnet`,
+   `sdk-manifests/10.0.100/microsoft.net.workload.mono.toolchain.current/10.0.105/` pins
+   the browser-wasm chain to `Microsoft.NETCore.App@10.0.5`, but the only targeting pack on
+   disk is `packs/Microsoft.NETCore.App.Ref/10.0.7/`. Regular builds survive via the
+   `PackageDownload` fallback at restore; Roslyn design-time builds (hot reload) never
+   restore and end up with **zero framework references and zero diagnostics** (the .NET SDK
+   deliberately does not error on a missing pack when `DesignTimeBuild=true`).
+
+This state is invisible everywhere else: builds pass, no error is emitted anywhere, and the
+downstream hot-reload warning does not name the cause. uno-check is the tool that can both
+**name it** and **fix it**.
+
+### Key objective
+
+Two new checkups:
+
+1. **Dotnet-roots divergence** — surface multi-root installations where the effective root
+   (what IDE/devserver tooling resolves) differs from the terminal's `PATH` dotnet.
+2. **Targeting-pack alignment** — for the effective root, verify that every
+   `Microsoft.NETCore.App` version pinned by installed mono-toolchain workload manifests
+   has its targeting pack available (SDK packs folder or NuGet cache), with
+   `dotnet workload update` as the automatic remediation — **on the affected root**.
+
+---
+
+## Verified facts (investigation grounding)
+
+| # | Fact | Consequence |
+|---|------|-------------|
+| F1 | `DotNetSdk` (uno-check) already prefers `DOTNET_ROOT` when set, and records the resolved root in `SharedState`. | The "effective root" definition already exists in the codebase; the new checkups anchor on it instead of inventing a second resolution. |
+| F2 | Workload manifests live per feature band under `<root>/sdk-manifests/<band>/microsoft.net.workload.mono.toolchain.current/<manifestVersion>/WorkloadManifest.json`; the pinned runtime version is readable from the manifest's pack versions (e.g. `Microsoft.NETCore.App.Runtime.Mono.browser-wasm`). | Alignment can be computed offline from the filesystem — no MSBuild evaluation required. |
+| F3 | The targeting pack satisfying that pin must exist either at `<root>/packs/Microsoft.NETCore.App.Ref/<version>/` or in the NuGet cache (`~/.nuget/packages/microsoft.netcore.app.ref/<version>/`, materialized by a prior restore's `PackageDownload`). | Two probe locations; either satisfies design-time builds. |
+| F4 | `dotnet workload uninstall` + `install` does **not** repair the misalignment: the manifest level stays where it is (loose manifests or pinned workload set); only `dotnet workload update` moves the manifests to match the SDK. | The remediation must be `workload update`, not reinstall — and must target the affected root explicitly (`<root>/dotnet workload update`). |
+| F5 | Field evidence that users repair the wrong root when several exist (F1 vs `PATH`). | The roots-divergence checkup is a prerequisite for every other remediation being applied where it matters; it must state *which* root the tooling uses. |
+
+---
+
+## Design
+
+### C1 — Dotnet-roots divergence checkup
+
+- Enumerate candidate roots:
+  - the resolved target of `dotnet` on `PATH` (symlinks followed, e.g.
+    `/usr/bin/dotnet → /usr/lib/dotnet`),
+  - `DOTNET_ROOT` (and `DOTNET_ROOT_<ARCH>` variants) when set,
+  - conventional locations per OS: `~/.dotnet`, `/usr/lib/dotnet`, `/usr/share/dotnet`
+    (Linux), `/usr/local/share/dotnet` (macOS), `%ProgramFiles%\dotnet` (Windows).
+- Report the inventory (root, SDKs present, workload-set/manifest mode) at info level.
+- **Warning** when the effective root (F1) differs from the `PATH` dotnet root, stating
+  explicitly: which root IDE/devserver tooling resolves, which root terminal commands hit,
+  and that workload/SDK maintenance commands must target the effective root.
+- No automatic fix (uno-check must not rewrite the user's environment); the value is the
+  diagnosis plus the exact commands (`<effective-root>/dotnet workload update`, or aligning
+  `DOTNET_ROOT`/`PATH`).
+
+### C2 — Targeting-pack alignment checkup
+
+For the **effective root** (F1):
+
+1. Enumerate installed workload manifests for the band(s) of the SDK(s) present
+   (`sdk-manifests/<band>/microsoft.net.workload.mono.toolchain.current/*/WorkloadManifest.json`).
+2. Extract the pinned `Microsoft.NETCore.App` version for browser-wasm (F2).
+3. Probe the targeting pack (F3): `<root>/packs/Microsoft.NETCore.App.Ref/<version>/` then
+   the NuGet cache.
+4. **Fail** when absent, with the message naming: the manifest (path + version), the pinned
+   version, the packs actually installed, and the consequence (silent hot-reload breakage —
+   link uno#23780).
+5. **Remediation** (uno-check's standard fix flow): run `dotnet workload update` **with the
+   effective root's muxer** (uno-check already drives workload operations through
+   `DotNetWorkloadManager`; respect the loose-manifests vs workload-set mode). Plan B when
+   `workload update` is refused/unavailable: restore a temporary minimal wasm project to
+   materialize the `PackageDownload` into the NuGet cache (satisfies F3 without touching
+   manifests).
+
+Scope note: the check targets the mono-toolchain manifest (wasm) because it is the one that
+pins a runtime version distinct from the SDK's bundled targeting pack; the mechanism is
+written so other manifests (android, maui) can be added later if a field case shows up.
+
+### C3 — Wiring
+
+- Both checkups registered in the standard manifest-driven checkup list, enabled on all
+  OSes (C1) and wherever wasm workloads are checked today (C2, alongside
+  `DotNetWorkloadsCheckup`).
+- C2 declares a dependency on the SDK checkup (needs the resolved root from `SharedState`).
+- `--fix` behavior: C1 never mutates; C2 fixes via the remediation above.
+
+---
+
+## Implementation map
+
+| Area | Change |
+|---|---|
+| `UnoCheck/Checkups/DotNetRootsCheckup.cs` (new) | C1: root enumeration, divergence detection, report. |
+| `UnoCheck/Checkups/DotNetTargetingPackAlignmentCheckup.cs` (new) | C2: manifest parsing, pack probing, failure + suggested `Solution`. |
+| `UnoCheck/Solutions/` (new solution/action) | `workload update` invocation bound to the effective root (reuse `DotNetWorkloadManager` plumbing); optional restore-based plan B. |
+| `UnoCheck/DotNet/DotNetSdk.cs` | Expose the "effective root vs PATH root" facts needed by C1 (today it resolves but does not compare). |
+| Manifest (`manifest.json` / checkup registration) | Register both checkups; C2 gated on wasm being a target platform. |
+| `UnoCheck.Tests` | See test plan. |
+
+---
+
+## Test plan
+
+**Unit (UnoCheck.Tests):**
+
+- Manifest parsing: fixture `WorkloadManifest.json` files (aligned / misaligned versions,
+  loose-manifest and workload-set layouts) → pinned-version extraction.
+- Pack probing: temp directory layouts for `<root>/packs/...` and NuGet-cache fallback →
+  present/absent classification.
+- Roots enumeration: fake environment (env vars + temp dirs + fake `dotnet` executables) →
+  divergence detected iff effective ≠ PATH root; symlink resolution covered.
+- Message composition: failure output contains manifest path, pinned version, installed
+  packs, and the per-root remediation command.
+
+**Integration / manual QA:**
+
+- Ubuntu with apt dotnet + `~/.dotnet` dotnet-install root + `DOTNET_ROOT` set: C1 warns
+  with the expected roles; C2 fails on a deliberately-stale manifest and `--fix` repairs it
+  (`workload update` on `~/.dotnet`), after which the uno#23780 hot-reload scenario works.
+- Single-root machine (Windows/macOS default installs): both checkups pass quietly — no
+  new noise on healthy environments.
+
+---
+
+## Out of scope / follow-ups
+
+- Devserver-side detection and restore-based recovery: uno, spec
+  `049-hotreload-workspace-missing-targeting-pack`
+  ([uno#23780](https://github.com/unoplatform/uno/issues/23780)).
+- Alignment checks for non-mono-toolchain manifests (android/maui) — mechanism ready,
+  added on field evidence.
+- Rewriting user environment (`DOTNET_ROOT`, `PATH`) — deliberately never done by uno-check.

--- a/specs/001-dotnet-roots-targeting-pack-alignment/spec.md
+++ b/specs/001-dotnet-roots-targeting-pack-alignment/spec.md
@@ -58,7 +58,9 @@ Two new checkups:
 - Enumerate candidate roots:
   - the resolved target of `dotnet` on `PATH` (symlinks followed, e.g.
     `/usr/bin/dotnet → /usr/lib/dotnet`),
-  - `DOTNET_ROOT` (and `DOTNET_ROOT_<ARCH>` variants) when set,
+  - the `DOTNET_ROOT`-family variables when set, probed in the host's order:
+    `DOTNET_ROOT_<ARCH>` (net6+ hosts), then `DOTNET_ROOT(x86)` for 32-bit processes,
+    then `DOTNET_ROOT`,
   - conventional locations per OS: `~/.dotnet`, `/usr/lib/dotnet`, `/usr/share/dotnet`
     (Linux), `/usr/local/share/dotnet` (macOS), `%ProgramFiles%\dotnet` (Windows).
 - Report the inventory (root, SDKs present, workload-set/manifest mode) at info level.


### PR DESCRIPTION
Closes #542

## What changed? 🚀

Adds the two checkups specified in `specs/001-dotnet-roots-targeting-pack-alignment` (included), catching the environment class that silently breaks Uno Hot Reload for WebAssembly while regular builds keep working (companion analysis: unoplatform/uno#23780):

- **`dotnetroots`** (`DotNetRootsCheckup`) — inventories the .NET installation roots (PATH-resolved `dotnet` with symlink chasing, `DOTNET_ROOT`, conventional per-OS locations) and warns when the effective root (DOTNET_ROOT-first — what uno-check and IDE/devserver tooling resolve) differs from the PATH root that terminal commands hit, naming which is which and the exact muxer to target for maintenance commands. Informational only — it never rewrites the user's environment.
- **`dotnettargetingpacks`** (`DotNetTargetingPackAlignmentCheckup`) — parses the installed mono-toolchain workload manifests of the effective root (both the flat and the versioned `sdk-manifests` layouts), extracts the `Microsoft.NETCore.App` version pinned for browser-wasm, and verifies the targeting pack is available under `packs/` or in the NuGet cache (`NUGET_PACKAGES` honored). When absent, restore-less design-time builds (hot reload) silently produce compilations without framework references; the checkup fails with the full context (manifest path, pinned version, installed packs) and offers a fix.
- **`DotNetWorkloadUpdateSolution`** — the `--fix`: runs `dotnet workload update` with the **explicit muxer of the affected root** (a bare `dotnet` would hit whatever PATH resolves first — precisely the failure mode being repaired; a plain `workload uninstall/install` does not move pinned manifests, only `update` does).

Both checkups declare a dependency on the `dotnet` checkup; the alignment checkup applies to the WebAssembly target platform.

## Testing

- 7 new unit tests (`DotNetTargetingPackAlignmentTests`) on filesystem fixtures: manifest enumeration across both layouts, pinned-version extraction, pack probing incl. the NuGet-cache fallback and the exact field case (manifest pins 10.0.5, only 10.0.7 installed).
- Builds green on `netcoreapp3.1` and `net6.0` (the symlink resolution uses `File.ResolveLinkTarget` on net6+, `readlink -f` otherwise).
- `uno-check list` shows both checkups ordered after their `dotnet` dependency.
- Full suite: 92/93 — the single failure (`ParseTfmsToTargetPlatforms`, expects `win32` for `net9.0-desktop`) pre-exists on a clean tree when running on Linux.