### PR TITLE
feat: automate manifest drift detection and release-pending alarms

### DIFF
--- a/.github/scripts/Check-ManifestDrift.ps1
+++ b/.github/scripts/Check-ManifestDrift.ps1
@@ -405,7 +405,13 @@ function Get-PackageVersion {
             }
         }
         catch {
-            if ($_.Exception.Response -and $_.Exception.Response.StatusCode.value__ -eq 404) { $reachable = $true }
+            # A 404 is a real answer from a reachable feed (the package is simply not on this
+            # source). Connection-level failures - DNS, TLS, timeout - throw exception types
+            # with no Response property at all, so this must go through Get-Prop: under
+            # StrictMode a bare $_.Exception.Response would terminate inside the catch, and a
+            # crashed checker reads as "no drift".
+            $status = Get-Prop (Get-Prop $_.Exception 'Response') 'StatusCode'
+            if ($null -ne $status -and [int] $status -eq 404) { $reachable = $true }
         }
     }
 
@@ -459,30 +465,47 @@ function Get-DotNetChannel {
 }
 
 function Test-UrlAlive {
+    <#  Returns 'alive', 'dead' or 'offline'.
+
+        'dead' is reserved for a definite answer from a working server (a non-429 4xx).
+        Anything else - DNS/TLS failure, timeout, 429, 5xx - is 'offline': unproven, not
+        broken. This distinction matters because url-dead is an Action-tier finding that
+        tells maintainers "users will fail to install", so a flaky runner must never
+        produce one. Callers must compare against 'alive' explicitly: every return value
+        here is a non-empty string, and so truthy. #>
     param([string] $Uri)
+
+    $definite = $false
 
     foreach ($method in @('Head', 'Get')) {
         try {
             $arguments = @{
-                Uri                  = $Uri
-                Method               = $method
-                TimeoutSec           = 60
-                MaximumRedirection   = 10
-                SkipHttpErrorCheck   = $true
-                ErrorAction          = 'Stop'
+                Uri                = $Uri
+                Method             = $method
+                TimeoutSec         = 30
+                MaximumRedirection = 10
+                MaximumRetryCount  = 2
+                RetryIntervalSec   = 5
+                SkipHttpErrorCheck = $true
+                ErrorAction        = 'Stop'
             }
             # Ask for a single byte so a GET fallback never downloads an installer.
             if ($method -eq 'Get') { $arguments['Headers'] = @{ Range = 'bytes=0-0' } }
 
             $response = Invoke-WebRequest @arguments
-            if ($response.StatusCode -lt 400) { return $true }
+            if ($response.StatusCode -lt 400) { return 'alive' }
+
+            # 429 and 5xx are the server having a bad day, not a missing file. A HEAD may
+            # also be refused (405) where a GET succeeds, so keep trying the next method.
+            if ($response.StatusCode -ne 429 -and $response.StatusCode -lt 500) { $definite = $true }
         }
         catch {
             continue
         }
     }
 
-    return $false
+    if ($definite) { return 'dead' }
+    return 'offline'
 }
 
 #endregion
@@ -627,9 +650,15 @@ function Test-ManifestUrl {
         $resolved = Resolve-ManifestVariable $url $Manifest.Variables
         if ($resolved -match '\$\(') { continue }
 
-        if (-not (Test-UrlAlive $resolved)) {
-            Add-Finding -Tier Action -Kind 'url-dead' -Manifest $Manifest.Name -Subject 'download url' `
-                -Current $resolved -Detail 'URL did not resolve. Users will fail to install this component.'
+        switch (Test-UrlAlive $resolved) {
+            'dead' {
+                Add-Finding -Tier Action -Kind 'url-dead' -Manifest $Manifest.Name -Subject 'download url' `
+                    -Current $resolved -Detail 'URL did not resolve. Users will fail to install this component.'
+            }
+            'offline' {
+                Add-Finding -Tier Advisory -Kind 'source-offline' -Manifest $Manifest.Name -Subject 'download url' `
+                    -Current $resolved -Detail 'URL could not be probed (timeout, connection failure or server error); its liveness is unproven for this run.'
+            }
         }
     }
 }
@@ -756,7 +785,7 @@ function Test-Advisory {
         if (-not $latestJdk -or (Compare-SemVer $latestJdk $current) -le 0) { continue }
 
         $probe = "https://aka.ms/download-jdk/microsoft-jdk-$latestJdk-windows-x64.msi"
-        if (Test-UrlAlive $probe) {
+        if ((Test-UrlAlive $probe) -eq 'alive') {
             Add-Finding -Tier Advisory -Kind 'openjdk' -Manifest $manifest.Name -Subject 'OPENJDK_VERSION' `
                 -Current $current -Latest $latestJdk -Detail 'Microsoft has published this JDK build.'
         }
@@ -789,9 +818,17 @@ function New-Report {
     $actions = @($Findings | Where-Object Tier -EQ 'Action')
     $advisories = @($Findings | Where-Object Tier -EQ 'Advisory')
 
+    # A source we could not read, or a pin we could not parse, means some subjects went
+    # unchecked this run. "No actions" then means "nothing proven", not "nothing wrong" -
+    # Sync-DriftIssue uses this to refuse to declare the drift resolved.
+    $degraded = @($Findings | Where-Object { $_.Kind -in @('source-offline', 'manifest-parse') })
+
     $body = [System.Text.StringBuilder]::new()
 
-    if ($actions.Count -eq 0) {
+    if ($actions.Count -eq 0 -and $degraded.Count -gt 0) {
+        [void] $body.AppendLine("No action items, but $($degraded.Count) check(s) could not be completed this run (see Advisory below). Drift is unproven, not absent.")
+    }
+    elseif ($actions.Count -eq 0) {
         [void] $body.AppendLine('No manifest drift detected. Every pinned .NET SDK, workload manifest and download URL is current.')
     }
     else {
@@ -823,13 +860,15 @@ function New-Report {
     $fingerprint = ([System.BitConverter]::ToString($hash) -replace '-', '').Substring(0, 16).ToLowerInvariant()
 
     [pscustomobject]@{
-        HasAction     = $actions.Count -gt 0
-        ActionCount   = $actions.Count
-        AdvisoryCount = $advisories.Count
-        Fingerprint   = $fingerprint
-        Findings      = $Findings
-        Markdown      = $body.ToString()
-        GeneratedUtc  = [datetimeoffset]::UtcNow.ToString('o')
+        HasAction       = $actions.Count -gt 0
+        ActionCount     = $actions.Count
+        AdvisoryCount   = $advisories.Count
+        SourcesDegraded = $degraded.Count -gt 0
+        DegradedCount   = $degraded.Count
+        Fingerprint     = $fingerprint
+        Findings        = $Findings
+        Markdown        = $body.ToString()
+        GeneratedUtc    = [datetimeoffset]::UtcNow.ToString('o')
     }
 }
 
@@ -883,7 +922,7 @@ if (-not $SkipGitCheck) { Test-ReleasePending $RepositoryRoot $ReleaseGraceDays 
 $report = New-Report $script:Findings $repositoryVersion
 
 Write-Host ''
-Write-Host "Action items: $($report.ActionCount) | Advisories: $($report.AdvisoryCount) | Fingerprint: $($report.Fingerprint)"
+Write-Host "Action items: $($report.ActionCount) | Advisories: $($report.AdvisoryCount) | Unproven: $($report.DegradedCount) | Fingerprint: $($report.Fingerprint)"
 Write-Host ''
 Write-Host $report.Markdown
 

--- a/.github/scripts/Check-ManifestDrift.ps1
+++ b/.github/scripts/Check-ManifestDrift.ps1
@@ -1,0 +1,911 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Detects when the Uno.Check manifests have fallen behind upstream .NET/tooling releases,
+    and when manifest changes on main are waiting for a stable release.
+
+.DESCRIPTION
+    The manifests under manifests/ are embedded resources in the Uno.Check package, so a
+    manifest change only reaches users once a new package is published. This script watches
+    the upstream release trains that drive those manifests and reports drift.
+
+    Checks performed:
+      * sdk-servicing    - a newer .NET SDK exists in the pinned feature band
+      * sdk-band-move    - a newer feature band exists for the pinned channel
+      * workload         - a newer workload manifest package is published
+      * url-dead         - a download URL in the manifest no longer resolves
+      * release-pending  - manifest commits on main are not in a stable release yet
+      * tool-version     - check.toolVersion asks for a tool newer than version.json
+      * channel-overlap  - the preview channel offers nothing beyond stable (advisory)
+      * xcode / openjdk  - newer releases exist (advisory; these are policy decisions)
+      * source-offline   - a data source could not be reached, so its checks are unproven
+
+    Findings are tiered:
+      Action   - something must be changed in the repository
+      Advisory - worth a look, but not automatically actionable
+
+.PARAMETER SelfTest
+    Runs the offline unit tests for the version/band helpers and exits. No network access.
+
+.EXAMPLE
+    ./Check-ManifestDrift.ps1 -SelfTest
+
+.EXAMPLE
+    ./Check-ManifestDrift.ps1 -JsonOut drift.json -MarkdownOut drift.md
+#>
+
+[CmdletBinding()]
+param(
+    [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path,
+    [string[]] $ManifestFile,
+    [string] $JsonOut,
+    [string] $MarkdownOut,
+    [int] $ReleaseGraceDays = 7,
+    [switch] $SkipAdvisory,
+    [switch] $SkipUrlCheck,
+    [switch] $SkipGitCheck,
+    [switch] $FailOnAction,
+    [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ProgressPreference = 'SilentlyContinue'
+
+$script:ReleasesIndexUrl = 'https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json'
+$script:XcodeReleasesUrl = 'https://xcodereleases.com/data.json'
+$script:FeedCache = @{}
+$script:ChannelCache = @{}
+$script:Findings = [System.Collections.Generic.List[object]]::new()
+
+#region version helpers
+
+function ConvertTo-SemVer {
+    <#  Parses a NuGet/SemVer2 style version into comparable parts. Returns $null when unparsable. #>
+    param([string] $Version)
+
+    if ([string]::IsNullOrWhiteSpace($Version)) { return $null }
+
+    $value = $Version.Trim()
+
+    $plus = $value.IndexOf('+')
+    if ($plus -ge 0) { $value = $value.Substring(0, $plus) }
+
+    $preRelease = $null
+    $dash = $value.IndexOf('-')
+    if ($dash -ge 0) {
+        $preRelease = $value.Substring($dash + 1)
+        $value = $value.Substring(0, $dash)
+    }
+
+    $numbers = @(0, 0, 0, 0)
+    $parts = $value.Split('.')
+    for ($i = 0; $i -lt $parts.Length -and $i -lt 4; $i++) {
+        $parsed = 0
+        if (-not [int]::TryParse($parts[$i], [ref] $parsed)) { return $null }
+        $numbers[$i] = $parsed
+    }
+
+    [pscustomobject]@{
+        Numbers      = $numbers
+        PreRelease   = $preRelease
+        IsPreRelease = -not [string]::IsNullOrEmpty($preRelease)
+        Original     = $Version
+    }
+}
+
+function Compare-SemVer {
+    <#  Returns -1/0/1, or $null when either side is unparsable. #>
+    param([string] $Left, [string] $Right)
+
+    $a = ConvertTo-SemVer $Left
+    $b = ConvertTo-SemVer $Right
+    if ($null -eq $a -or $null -eq $b) { return $null }
+
+    for ($i = 0; $i -lt 4; $i++) {
+        if ($a.Numbers[$i] -ne $b.Numbers[$i]) {
+            return [Math]::Sign($a.Numbers[$i] - $b.Numbers[$i])
+        }
+    }
+
+    if (-not $a.IsPreRelease -and -not $b.IsPreRelease) { return 0 }
+    if (-not $a.IsPreRelease) { return 1 }
+    if (-not $b.IsPreRelease) { return -1 }
+
+    $left = $a.PreRelease.Split('.')
+    $right = $b.PreRelease.Split('.')
+    $max = [Math]::Max($left.Length, $right.Length)
+
+    for ($i = 0; $i -lt $max; $i++) {
+        if ($i -ge $left.Length) { return -1 }
+        if ($i -ge $right.Length) { return 1 }
+
+        $x = $left[$i]
+        $y = $right[$i]
+        $xn = 0
+        $yn = 0
+        $xIsNumeric = [int]::TryParse($x, [ref] $xn)
+        $yIsNumeric = [int]::TryParse($y, [ref] $yn)
+
+        if ($xIsNumeric -and $yIsNumeric) {
+            if ($xn -ne $yn) { return [Math]::Sign($xn - $yn) }
+            continue
+        }
+
+        # Numeric identifiers always have lower precedence than alphanumeric ones.
+        if ($xIsNumeric) { return -1 }
+        if ($yIsNumeric) { return 1 }
+
+        $ordinal = [string]::CompareOrdinal($x, $y)
+        if ($ordinal -ne 0) { return [Math]::Sign($ordinal) }
+    }
+
+    return 0
+}
+
+function Get-FeatureBand {
+    <#  10.0.201 -> 10.0.200 (the numeric band), used to group SDK releases. #>
+    param([string] $SdkVersion)
+
+    $semver = ConvertTo-SemVer $SdkVersion
+    if ($null -eq $semver) { return $null }
+
+    $band = [Math]::Floor($semver.Numbers[2] / 100) * 100
+    '{0}.{1}.{2}' -f $semver.Numbers[0], $semver.Numbers[1], $band
+}
+
+function Format-FeatureBand {
+    param([string] $SdkVersion)
+
+    $band = Get-FeatureBand $SdkVersion
+    if (-not $band) { return '?' }
+    $band.Substring(0, $band.Length - 2) + 'xx'
+}
+
+function Get-ChannelVersion {
+    param([string] $SdkVersion)
+
+    $semver = ConvertTo-SemVer $SdkVersion
+    if ($null -eq $semver) { return $null }
+    '{0}.{1}' -f $semver.Numbers[0], $semver.Numbers[1]
+}
+
+function Get-Prop {
+    <#  StrictMode-safe property access: a manifest without an optional node must degrade
+        to "nothing to check", never crash the checker (a crashed checker reads as no drift). #>
+    param($Object, [string] $Name, $Default = $null)
+
+    if ($null -eq $Object) { return $Default }
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property -or $null -eq $property.Value) { return $Default }
+    $property.Value
+}
+
+function Get-LatestVersion {
+    param([string[]] $Versions, [bool] $AllowPreRelease)
+
+    $best = $null
+    foreach ($version in $Versions) {
+        $semver = ConvertTo-SemVer $version
+        if ($null -eq $semver) { continue }
+        if ($semver.IsPreRelease -and -not $AllowPreRelease) { continue }
+        if ($null -eq $best -or (Compare-SemVer $version $best) -gt 0) { $best = $version }
+    }
+    $best
+}
+
+#endregion
+
+#region findings
+
+function Add-Finding {
+    param(
+        [ValidateSet('Action', 'Advisory')] [string] $Tier,
+        [string] $Kind,
+        [string] $Manifest,
+        [string] $Subject,
+        [string] $Current,
+        [string] $Latest,
+        [string] $Detail
+    )
+
+    $script:Findings.Add([pscustomobject]@{
+            Tier     = $Tier
+            Kind     = $Kind
+            Manifest = $Manifest
+            Subject  = $Subject
+            Current  = $Current
+            Latest   = $Latest
+            Detail   = $Detail
+        })
+}
+
+#endregion
+
+#region self test
+
+function Invoke-SelfTest {
+    $failures = [System.Collections.Generic.List[string]]::new()
+
+    function Assert-Equal {
+        param($Expected, $Actual, [string] $Because)
+        if ("$Expected" -ne "$Actual") {
+            $failures.Add("$Because -- expected '$Expected', got '$Actual'")
+        }
+    }
+
+    Assert-Equal 1 (Compare-SemVer '36.1.69' '36.1.43') 'newer patch wins'
+    Assert-Equal -1 (Compare-SemVer '26.2.10217' '26.5.10301') 'older minor loses'
+    Assert-Equal 0 (Compare-SemVer '10.0.201' '10.0.201.0') 'missing 4th part is zero'
+    Assert-Equal 1 (Compare-SemVer '11.0.100' '11.0.100-preview.6') 'release beats prerelease'
+    Assert-Equal -1 (Compare-SemVer '11.0.100-preview.6' '11.0.100-preview.7') 'prerelease ordinal ordering'
+    Assert-Equal 1 (Compare-SemVer '11.0.100-preview.6.26359.118' '11.0.100-preview.6.26359.117') 'prerelease build ordering'
+    Assert-Equal -1 (Compare-SemVer '1.0.0-alpha.1' '1.0.0-alpha.beta') 'numeric identifier sorts below alphanumeric'
+    Assert-Equal $null (Compare-SemVer 'not-a-version' '1.0.0') 'unparsable returns null'
+
+    Assert-Equal '10.0.200' (Get-FeatureBand '10.0.201') 'band of 10.0.201'
+    Assert-Equal '10.0.100' (Get-FeatureBand '10.0.100') 'band of 10.0.100'
+    Assert-Equal '11.0.100' (Get-FeatureBand '11.0.100-preview.6.26359.118') 'band of a preview sdk'
+    Assert-Equal '10.0.2xx' (Format-FeatureBand '10.0.201') 'formatted band'
+    Assert-Equal '10.0' (Get-ChannelVersion '10.0.302') 'channel of 10.0.302'
+
+    Assert-Equal '36.1.69' (Get-LatestVersion @('36.1.43', '36.1.69', '36.1.53') $false) 'latest stable'
+    Assert-Equal '36.1.69' (Get-LatestVersion @('36.1.69', '37.0.0-preview.1') $false) 'prerelease excluded'
+    Assert-Equal '37.0.0-preview.1' (Get-LatestVersion @('36.1.69', '37.0.0-preview.1') $true) 'prerelease included'
+
+    $variables = @{ 'IOS_SDK_VERSION' = '26.2.10217/10.0.100'; 'DOTNET_SDK_VERSION' = '10.0.201' }
+    Assert-Equal '26.2.10217/10.0.100' (Resolve-ManifestVariable '$(IOS_SDK_VERSION)' $variables) 'variable substitution'
+    Assert-Equal 'sdk-10.0.201.exe' (Resolve-ManifestVariable 'sdk-$(DOTNET_SDK_VERSION).exe' $variables) 'embedded substitution'
+    Assert-Equal '$(UNKNOWN)' (Resolve-ManifestVariable '$(UNKNOWN)' $variables) 'unknown variable is left alone'
+
+    Assert-Equal '26.2.10217' (Split-WorkloadVersion '26.2.10217/10.0.100').Version 'workload version part'
+    Assert-Equal '10.0.100' (Split-WorkloadVersion '26.2.10217/10.0.100').Band 'workload band part'
+    Assert-Equal '' (Split-WorkloadVersion '36.1.43').Band 'workload without band'
+
+    $shape = [pscustomobject]@{ present = 'value'; nullish = $null }
+    Assert-Equal 'value' (Get-Prop $shape 'present') 'Get-Prop existing property'
+    Assert-Equal 'fallback' (Get-Prop $shape 'absent' 'fallback') 'Get-Prop missing property'
+    Assert-Equal 'fallback' (Get-Prop $shape 'nullish' 'fallback') 'Get-Prop null-valued property'
+    Assert-Equal 'fallback' (Get-Prop $null 'anything' 'fallback') 'Get-Prop null object'
+
+    if ($failures.Count -gt 0) {
+        Write-Host "Self-test FAILED ($($failures.Count)):" -ForegroundColor Red
+        $failures | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+        return $false
+    }
+
+    Write-Host 'Self-test passed.' -ForegroundColor Green
+    return $true
+}
+
+#endregion
+
+#region manifest parsing
+
+function Resolve-ManifestVariable {
+    param([string] $Value, [hashtable] $Variables)
+
+    if ([string]::IsNullOrEmpty($Value)) { return $Value }
+
+    $result = $Value
+    foreach ($key in $Variables.Keys) {
+        $result = $result.Replace('$(' + $key + ')', [string] $Variables[$key])
+    }
+    $result
+}
+
+function Split-WorkloadVersion {
+    <#  '26.2.10217/10.0.100' -> Version + Band. The band half mirrors the packageId suffix. #>
+    param([string] $Value)
+
+    $parts = ($Value ?? '').Split('/')
+    [pscustomobject]@{
+        Version = $parts[0]
+        Band    = if ($parts.Length -gt 1) { $parts[1] } else { '' }
+    }
+}
+
+function Read-CheckManifest {
+    param([string] $Path)
+
+    $json = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    $check = Get-Prop $json 'check'
+    if ($null -eq $check) {
+        throw "'$Path' has no top-level 'check' node; it is not an Uno.Check manifest."
+    }
+
+    $variables = @{}
+    $variableNode = Get-Prop $check 'variables'
+    if ($variableNode) {
+        foreach ($property in $variableNode.PSObject.Properties) {
+            $variables[$property.Name] = [string] $property.Value
+        }
+    }
+
+    [pscustomobject]@{
+        Name      = [IO.Path]::GetFileNameWithoutExtension($Path) -replace '\.manifest$', ''
+        Path      = $Path
+        Json      = $json
+        Check     = $check
+        Variables = $variables
+    }
+}
+
+function Get-VariableNameFor {
+    <#  Maps a raw manifest value back to the variable that produced it, for actionable reporting. #>
+    param([string] $RawValue, [hashtable] $Variables, [string] $Fallback)
+
+    if ($RawValue -match '^\$\(([^)]+)\)$') { return $Matches[1] }
+
+    foreach ($key in $Variables.Keys) {
+        if ($Variables[$key] -eq $RawValue) { return $key }
+    }
+
+    $Fallback
+}
+
+#endregion
+
+#region remote sources
+
+function Invoke-Json {
+    param([string] $Uri, [int] $TimeoutSec = 60)
+
+    Invoke-RestMethod -Uri $Uri -TimeoutSec $TimeoutSec -MaximumRetryCount 2 -RetryIntervalSec 5 -Headers @{ 'User-Agent' = 'uno-check-manifest-drift' }
+}
+
+function Get-FlatContainerBase {
+    param([string] $SourceUrl)
+
+    if ($script:FeedCache.ContainsKey($SourceUrl)) { return $script:FeedCache[$SourceUrl] }
+
+    $base = $null
+    try {
+        if ($SourceUrl -match 'api\.nuget\.org') {
+            $base = 'https://api.nuget.org/v3-flatcontainer/'
+        }
+        else {
+            $index = Invoke-Json $SourceUrl
+            $resource = $index.resources | Where-Object { $_.'@type' -like 'PackageBaseAddress/*' } | Select-Object -First 1
+            if ($resource) { $base = [string] $resource.'@id' }
+        }
+    }
+    catch {
+        Write-Warning "Could not resolve NuGet feed '$SourceUrl': $($_.Exception.Message)"
+    }
+
+    if ($base -and -not $base.EndsWith('/')) { $base += '/' }
+    $script:FeedCache[$SourceUrl] = $base
+    $base
+}
+
+function Get-PackageVersion {
+    <#  Union of versions across every configured source; a 404 on one feed is expected.
+        Tracks which source carried each version, so a build that only exists on a dotnet
+        build feed is not reported as if Microsoft had shipped it. #>
+    param([string] $PackageId, [string[]] $Sources)
+
+    $sourcesByVersion = @{}
+    $reachable = $false
+
+    foreach ($source in $Sources) {
+        $base = Get-FlatContainerBase $source
+        if (-not $base) { continue }
+
+        $uri = "$base$($PackageId.ToLowerInvariant())/index.json"
+        try {
+            $response = Invoke-Json $uri
+            $reachable = $true
+            foreach ($version in $response.versions) {
+                $key = [string] $version
+                if (-not $sourcesByVersion.ContainsKey($key)) {
+                    $sourcesByVersion[$key] = [System.Collections.Generic.List[string]]::new()
+                }
+                $sourcesByVersion[$key].Add($source)
+            }
+        }
+        catch {
+            if ($_.Exception.Response -and $_.Exception.Response.StatusCode.value__ -eq 404) { $reachable = $true }
+        }
+    }
+
+    [pscustomobject]@{
+        Versions         = @($sourcesByVersion.Keys)
+        SourcesByVersion = $sourcesByVersion
+        Reachable        = $reachable
+    }
+}
+
+function Get-DotNetChannel {
+    param([string] $ChannelVersion)
+
+    if ($script:ChannelCache.ContainsKey($ChannelVersion)) { return $script:ChannelCache[$ChannelVersion] }
+
+    $result = $null
+    try {
+        $index = Invoke-Json $script:ReleasesIndexUrl
+        $channel = $index.'releases-index' | Where-Object { $_.'channel-version' -eq $ChannelVersion } | Select-Object -First 1
+
+        if ($channel) {
+            $releases = Invoke-Json $channel.'releases.json'
+            $sdkVersions = [System.Collections.Generic.List[string]]::new()
+
+            foreach ($release in $releases.releases) {
+                $candidates = @()
+                if ($release.PSObject.Properties.Name -contains 'sdks' -and $release.sdks) { $candidates += $release.sdks }
+                if ($release.PSObject.Properties.Name -contains 'sdk' -and $release.sdk) { $candidates += $release.sdk }
+
+                foreach ($sdk in $candidates) {
+                    if ($sdk.version -and -not $sdkVersions.Contains([string] $sdk.version)) {
+                        $sdkVersions.Add([string] $sdk.version)
+                    }
+                }
+            }
+
+            $result = [pscustomobject]@{
+                ChannelVersion = $ChannelVersion
+                SupportPhase   = [string] $channel.'support-phase'
+                LatestSdk      = [string] $channel.'latest-sdk'
+                SdkVersions    = $sdkVersions
+            }
+        }
+    }
+    catch {
+        Write-Warning "Could not read .NET release metadata for channel $ChannelVersion : $($_.Exception.Message)"
+    }
+
+    $script:ChannelCache[$ChannelVersion] = $result
+    $result
+}
+
+function Test-UrlAlive {
+    param([string] $Uri)
+
+    foreach ($method in @('Head', 'Get')) {
+        try {
+            $arguments = @{
+                Uri                  = $Uri
+                Method               = $method
+                TimeoutSec           = 60
+                MaximumRedirection   = 10
+                SkipHttpErrorCheck   = $true
+                ErrorAction          = 'Stop'
+            }
+            # Ask for a single byte so a GET fallback never downloads an installer.
+            if ($method -eq 'Get') { $arguments['Headers'] = @{ Range = 'bytes=0-0' } }
+
+            $response = Invoke-WebRequest @arguments
+            if ($response.StatusCode -lt 400) { return $true }
+        }
+        catch {
+            continue
+        }
+    }
+
+    return $false
+}
+
+#endregion
+
+#region checks
+
+function Get-ManifestSdk {
+    param($Manifest)
+    @(Get-Prop (Get-Prop $Manifest.Check 'dotnet') 'sdks' @())
+}
+
+function Test-SdkVersion {
+    param($Manifest)
+
+    foreach ($sdk in (Get-ManifestSdk $Manifest)) {
+        $pinnedRaw = [string] $sdk.version
+        $pinned = Resolve-ManifestVariable $pinnedRaw $Manifest.Variables
+        $variable = Get-VariableNameFor $pinnedRaw $Manifest.Variables 'DOTNET_SDK_VERSION'
+
+        $channelVersion = Get-ChannelVersion $pinned
+        if (-not $channelVersion) {
+            Add-Finding -Tier Advisory -Kind 'manifest-parse' -Manifest $Manifest.Name -Subject $variable `
+                -Current $pinned -Detail 'Pinned SDK version could not be parsed.'
+            continue
+        }
+
+        $channel = Get-DotNetChannel $channelVersion
+        if (-not $channel) {
+            Add-Finding -Tier Advisory -Kind 'source-offline' -Manifest $Manifest.Name -Subject $variable `
+                -Current $pinned -Detail "Release metadata for channel $channelVersion was unreachable; SDK drift is unproven for this run."
+            continue
+        }
+
+        $allowPreRelease = (ConvertTo-SemVer $pinned).IsPreRelease
+        $pinnedBand = Get-FeatureBand $pinned
+
+        $inBand = Get-LatestVersion (($channel.SdkVersions | Where-Object { (Get-FeatureBand $_) -eq $pinnedBand })) $allowPreRelease
+        if ($inBand -and (Compare-SemVer $inBand $pinned) -gt 0) {
+            Add-Finding -Tier Action -Kind 'sdk-servicing' -Manifest $Manifest.Name -Subject $variable `
+                -Current $pinned -Latest $inBand `
+                -Detail "Newer servicing release in band $(Format-FeatureBand $pinned)."
+        }
+
+        $overall = Get-LatestVersion $channel.SdkVersions $allowPreRelease
+        if ($overall -and (Get-FeatureBand $overall) -ne $pinnedBand -and (Compare-SemVer $overall $pinned) -gt 0) {
+            Add-Finding -Tier Advisory -Kind 'sdk-band-move' -Manifest $Manifest.Name -Subject $variable `
+                -Current $pinned -Latest $overall `
+                -Detail "Feature band $(Format-FeatureBand $overall) is available (pinned band is $(Format-FeatureBand $pinned)). Moving bands is a deliberate call: re-verify the workload packageId suffixes on a clean machine."
+        }
+    }
+}
+
+function Test-Workload {
+    param($Manifest)
+
+    $seen = @{}
+
+    foreach ($sdk in (Get-ManifestSdk $Manifest)) {
+        $sources = @(Get-Prop $sdk 'packageSources' @())
+        if ($sources.Count -eq 0) { $sources = @('https://api.nuget.org/v3/index.json') }
+
+        foreach ($workload in @(Get-Prop $sdk 'workloads' @())) {
+            $packageId = [string] $workload.packageId
+            $pinnedRaw = [string] $workload.version
+            $variable = Get-VariableNameFor $pinnedRaw $Manifest.Variables $workload.workloadId
+
+            # maui and maui-android share one manifest package; report the variable once.
+            $key = "$packageId|$variable"
+            if ($seen.ContainsKey($key)) { continue }
+            $seen[$key] = $true
+
+            $pinned = Split-WorkloadVersion (Resolve-ManifestVariable $pinnedRaw $Manifest.Variables)
+            $pinnedSemVer = ConvertTo-SemVer $pinned.Version
+            if ($null -eq $pinnedSemVer) {
+                Add-Finding -Tier Advisory -Kind 'manifest-parse' -Manifest $Manifest.Name -Subject $variable `
+                    -Current $pinned.Version -Detail 'Pinned workload version could not be parsed (unresolved variable?), so this workload is not being drift-checked.'
+                continue
+            }
+
+            $lookup = Get-PackageVersion -PackageId $packageId -Sources $sources
+
+            if (-not $lookup.Reachable) {
+                Add-Finding -Tier Advisory -Kind 'source-offline' -Manifest $Manifest.Name -Subject $variable `
+                    -Current $pinned.Version -Detail "No configured feed answered for $packageId; workload drift is unproven for this run."
+                continue
+            }
+
+            if ($lookup.Versions.Count -eq 0) {
+                # packageId is only used in the tool's diagnostic output today (DotNetWorkloadsCheckup),
+                # so a stale id does not break installs - but it does blind this drift check.
+                Add-Finding -Tier Action -Kind 'workload-unknown-package' -Manifest $Manifest.Name -Subject $variable `
+                    -Current $pinned.Version `
+                    -Detail "No such package as $packageId on the configured feeds, so this workload's version is NOT being drift-checked. The id is only used in the tool's error text today, so installs still work, but it should be corrected."
+                continue
+            }
+
+            $allowPreRelease = $pinnedSemVer.IsPreRelease
+            $latest = Get-LatestVersion $lookup.Versions $allowPreRelease
+            if (-not $latest) { continue }
+
+            $comparison = Compare-SemVer $latest $pinned.Version
+            if ($null -ne $comparison -and $comparison -gt 0) {
+                $suggested = if ($pinned.Band) { "$latest/$($pinned.Band)" } else { $latest }
+                $foundOn = @($lookup.SourcesByVersion[$latest])
+                $onNuGetOrg = @($foundOn | Where-Object { $_ -match 'api\.nuget\.org' }).Count -gt 0
+
+                # A stable channel should only chase versions Microsoft has actually shipped publicly.
+                # Preview channels legitimately consume the dotnet build feeds first.
+                $tier = 'Action'
+                $note = ''
+                if (-not $onNuGetOrg -and -not $allowPreRelease) {
+                    $tier = 'Advisory'
+                    $note = ' Not on nuget.org yet (build feed only) - may be an unreleased build.'
+                }
+
+                Add-Finding -Tier $tier -Kind 'workload' -Manifest $Manifest.Name -Subject $variable `
+                    -Current (Resolve-ManifestVariable $pinnedRaw $Manifest.Variables) -Latest $suggested `
+                    -Detail "$packageId published $latest.$note"
+            }
+        }
+    }
+}
+
+function Test-ManifestUrl {
+    param($Manifest)
+
+    $urls = [System.Collections.Generic.List[string]]::new()
+
+    $openJdkUrls = Get-Prop (Get-Prop $Manifest.Check 'openjdk') 'urls'
+    if ($openJdkUrls) {
+        foreach ($property in $openJdkUrls.PSObject.Properties) { $urls.Add([string] $property.Value) }
+    }
+
+    foreach ($sdk in (Get-ManifestSdk $Manifest)) {
+        $sdkUrls = Get-Prop $sdk 'urls'
+        if ($sdkUrls) {
+            foreach ($property in $sdkUrls.PSObject.Properties) { $urls.Add([string] $property.Value) }
+        }
+    }
+
+    foreach ($url in ($urls | Select-Object -Unique)) {
+        $resolved = Resolve-ManifestVariable $url $Manifest.Variables
+        if ($resolved -match '\$\(') { continue }
+
+        if (-not (Test-UrlAlive $resolved)) {
+            Add-Finding -Tier Action -Kind 'url-dead' -Manifest $Manifest.Name -Subject 'download url' `
+                -Current $resolved -Detail 'URL did not resolve. Users will fail to install this component.'
+        }
+    }
+}
+
+function Test-ToolVersion {
+    param($Manifest, [string] $RepositoryVersion)
+
+    $toolVersion = [string] (Get-Prop $Manifest.Check 'toolVersion' '')
+
+    if ([string]::IsNullOrWhiteSpace($toolVersion)) {
+        Add-Finding -Tier Action -Kind 'tool-version' -Manifest $Manifest.Name -Subject 'check.toolVersion' `
+            -Detail 'Manifest does not declare check.toolVersion; the tool aborts on this manifest under --ci.'
+        return
+    }
+
+    if (-not $RepositoryVersion) { return }
+
+    if ((Compare-SemVer $toolVersion $RepositoryVersion) -gt 0) {
+        Add-Finding -Tier Action -Kind 'tool-version' -Manifest $Manifest.Name -Subject 'check.toolVersion' `
+            -Current $toolVersion -Latest $RepositoryVersion `
+            -Detail "Manifest requires a tool version newer than version.json ($RepositoryVersion). Every user on this manifest gets an update warning that no release can satisfy."
+    }
+}
+
+function Test-ChannelOverlap {
+    param($Stable, $Preview)
+
+    if (-not $Stable -or -not $Preview) { return }
+
+    $differences = $Preview.Variables.Keys | Where-Object {
+        -not $Stable.Variables.ContainsKey($_) -or $Stable.Variables[$_] -ne $Preview.Variables[$_]
+    }
+
+    if (-not $differences) {
+        Add-Finding -Tier Advisory -Kind 'channel-overlap' -Manifest $Preview.Name -Subject 'variables' `
+            -Detail 'The preview manifest pins exactly the same versions as stable, so --pre currently gives users nothing extra. Expected while the current major is GA with no in-band preview; otherwise the preview channel needs a bump.'
+    }
+}
+
+function Test-ReleasePending {
+    param([string] $Root, [int] $GraceDays)
+
+    Push-Location $Root
+    try {
+        $tags = @(git tag --list --sort=-v:refname 2>$null) | Where-Object { $_ -match '^\d+\.\d+(\.\d+)?$' }
+        if (-not $tags -or $tags.Count -eq 0) {
+            Add-Finding -Tier Advisory -Kind 'source-offline' -Manifest 'repository' -Subject 'release tags' `
+                -Detail 'No stable release tags found. Fetch tags (fetch-depth: 0) for the release-pending check to work.'
+            return
+        }
+
+        $lastTag = $tags[0]
+
+        $head = 'HEAD'
+        if (git rev-parse --verify --quiet origin/main 2>$null) { $head = 'origin/main' }
+
+        $log = @(git log --format='%H%x09%cI%x09%s' "$lastTag..$head" -- manifests/ 2>$null)
+        if (-not $log -or $log.Count -eq 0) { return }
+
+        $oldest = $log[-1].Split("`t")
+        $oldestDate = [datetimeoffset]::Parse($oldest[1])
+        $age = [int] ([datetimeoffset]::UtcNow - $oldestDate).TotalDays
+        $tier = if ($age -ge $GraceDays) { 'Action' } else { 'Advisory' }
+
+        $subjects = ($log | ForEach-Object { ($_ -split "`t")[2] } | Select-Object -First 5) -join '; '
+
+        Add-Finding -Tier $tier -Kind 'release-pending' -Manifest 'repository' -Subject "since $lastTag" `
+            -Current "$($log.Count) manifest commit(s), oldest $age day(s) old" -Latest $lastTag `
+            -Detail "Manifest changes are on $head but not in a stable release. Users still get the versions from $lastTag until a release/stable branch is cut. Commits: $subjects"
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Test-Advisory {
+    param($Manifests)
+
+    # Xcode: the manifest minimum is a policy decision, so this is never an Action.
+    try {
+        $xcode = Invoke-Json $script:XcodeReleasesUrl
+        # Entries are newest-first; the first one whose release object says release=true is the latest GA.
+        $latestRelease = $xcode | Where-Object { (Get-Prop (Get-Prop (Get-Prop $_ 'version') 'release') 'release' $false) -eq $true } | Select-Object -First 1
+        if ($latestRelease) {
+            $latestXcode = [string] $latestRelease.version.number
+            foreach ($manifest in $Manifests) {
+                $minimum = [string] (Get-Prop (Get-Prop $manifest.Check 'xcode') 'minimumVersion' '')
+                if (-not $minimum) { continue }
+                if ((Compare-SemVer $latestXcode $minimum) -gt 0) {
+                    Add-Finding -Tier Advisory -Kind 'xcode' -Manifest $manifest.Name -Subject 'xcode.minimumVersion' `
+                        -Current $minimum -Latest $latestXcode `
+                        -Detail 'A newer Xcode GA exists. Only raise the minimum once the matching iOS/tvOS/MacCatalyst bindings are pinned, or macOS users are told to upgrade for workloads that do not exist yet.'
+                }
+            }
+        }
+    }
+    catch {
+        Write-Warning "Xcode release data unavailable: $($_.Exception.Message)"
+    }
+
+    # OpenJDK: track the GA line of whatever major each manifest pins (17 today, whatever
+    # tomorrow), and only suggest a version Microsoft has actually published.
+    $jdkLatestByMajor = @{}
+    foreach ($manifest in $Manifests) {
+        if (-not $manifest.Variables.ContainsKey('OPENJDK_VERSION')) { continue }
+        $current = $manifest.Variables['OPENJDK_VERSION']
+        $currentSemVer = ConvertTo-SemVer $current
+        if ($null -eq $currentSemVer) { continue }
+
+        $major = $currentSemVer.Numbers[0]
+        if (-not $jdkLatestByMajor.ContainsKey($major)) {
+            $jdkLatestByMajor[$major] = $null
+            try {
+                $uri = 'https://api.adoptium.net/v3/info/release_versions?version=%5B{0}%2C{1}%29&release_type=ga&page_size=1&sort_order=DESC' -f $major, ($major + 1)
+                $adoptium = Invoke-Json $uri
+                $jdkLatestByMajor[$major] = [string] $adoptium.versions[0].semver -replace '\+.*$', ''
+            }
+            catch {
+                Write-Warning "OpenJDK $major release data unavailable: $($_.Exception.Message)"
+            }
+        }
+
+        $latestJdk = $jdkLatestByMajor[$major]
+        if (-not $latestJdk -or (Compare-SemVer $latestJdk $current) -le 0) { continue }
+
+        $probe = "https://aka.ms/download-jdk/microsoft-jdk-$latestJdk-windows-x64.msi"
+        if (Test-UrlAlive $probe) {
+            Add-Finding -Tier Advisory -Kind 'openjdk' -Manifest $manifest.Name -Subject 'OPENJDK_VERSION' `
+                -Current $current -Latest $latestJdk -Detail 'Microsoft has published this JDK build.'
+        }
+    }
+}
+
+#endregion
+
+#region reporting
+
+function Format-FindingTable {
+    param($Findings)
+
+    $lines = @('| Manifest | What | Pinned | Available | Notes |', '| --- | --- | --- | --- | --- |')
+    foreach ($finding in $Findings) {
+        $lines += '| {0} | `{1}` ({2}) | {3} | {4} | {5} |' -f `
+            $finding.Manifest,
+        $finding.Subject,
+        $finding.Kind,
+        ($(if ($finding.Current) { '`' + $finding.Current + '`' } else { '—' })),
+        ($(if ($finding.Latest) { '`' + $finding.Latest + '`' } else { '—' })),
+        ($finding.Detail -replace '\|', '\|')
+    }
+    $lines -join "`n"
+}
+
+function New-Report {
+    param($Findings, [string] $RepositoryVersion)
+
+    $actions = @($Findings | Where-Object Tier -EQ 'Action')
+    $advisories = @($Findings | Where-Object Tier -EQ 'Advisory')
+
+    $body = [System.Text.StringBuilder]::new()
+
+    if ($actions.Count -eq 0) {
+        [void] $body.AppendLine('No manifest drift detected. Every pinned .NET SDK, workload manifest and download URL is current.')
+    }
+    else {
+        [void] $body.AppendLine("### Action required ($($actions.Count))")
+        [void] $body.AppendLine()
+        [void] $body.AppendLine((Format-FindingTable $actions))
+        [void] $body.AppendLine()
+        [void] $body.AppendLine('**How to act on this**')
+        [void] $body.AppendLine()
+        [void] $body.AppendLine('1. Do not copy the "Available" column straight into the manifest. It is a drift signal, not a validated set.')
+        [void] $body.AppendLine('2. Follow `AGENTS.md` section 5: install the target SDK into a clean folder, `dotnet workload install ios android maui catalyst tvos wasm-tools`, then `dotnet workload list` and transcribe the **Manifest Version** column verbatim (the `version/band` form).')
+        [void] $body.AppendLine('3. Update the `check.variables` block of the affected manifest(s) and open a PR. The CI matrix validates all three manifests on Windows, macOS and Linux.')
+        [void] $body.AppendLine('4. Merging to `main` only publishes a `-dev` prerelease. Users get nothing until a `release/stable/X.Y` branch is cut.')
+    }
+
+    if ($advisories.Count -gt 0) {
+        [void] $body.AppendLine()
+        [void] $body.AppendLine("### Advisory ($($advisories.Count))")
+        [void] $body.AppendLine()
+        [void] $body.AppendLine((Format-FindingTable $advisories))
+    }
+
+    [void] $body.AppendLine()
+    [void] $body.AppendLine('---')
+    [void] $body.AppendLine("Repository version: ``$RepositoryVersion`` · Checked $([datetimeoffset]::UtcNow.ToString('yyyy-MM-dd HH:mm')) UTC")
+
+    $fingerprintSource = ($actions | ForEach-Object { '{0}|{1}|{2}|{3}' -f $_.Kind, $_.Manifest, $_.Subject, $_.Latest } | Sort-Object) -join "`n"
+    $hash = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($fingerprintSource))
+    $fingerprint = ([System.BitConverter]::ToString($hash) -replace '-', '').Substring(0, 16).ToLowerInvariant()
+
+    [pscustomobject]@{
+        HasAction     = $actions.Count -gt 0
+        ActionCount   = $actions.Count
+        AdvisoryCount = $advisories.Count
+        Fingerprint   = $fingerprint
+        Findings      = $Findings
+        Markdown      = $body.ToString()
+        GeneratedUtc  = [datetimeoffset]::UtcNow.ToString('o')
+    }
+}
+
+#endregion
+
+# ---------------------------------------------------------------------------
+
+if ($SelfTest) {
+    exit ($(if (Invoke-SelfTest) { 0 } else { 1 }))
+}
+
+if (-not (Invoke-SelfTest)) {
+    Write-Error 'Self-test failed; refusing to report drift with broken version comparison.'
+    exit 1
+}
+
+if (-not $ManifestFile -or $ManifestFile.Count -eq 0) {
+    $ManifestFile = @(Get-ChildItem -Path (Join-Path $RepositoryRoot 'manifests') -Filter '*.manifest.json' | Sort-Object Name | Select-Object -ExpandProperty FullName)
+}
+
+$repositoryVersion = $null
+$versionJsonPath = Join-Path $RepositoryRoot 'version.json'
+if (Test-Path $versionJsonPath) {
+    $versionJson = Get-Content -LiteralPath $versionJsonPath -Raw | ConvertFrom-Json
+    $repositoryVersion = ([string] $versionJson.version) -replace '-.*$', ''
+}
+
+$manifests = @()
+foreach ($path in $ManifestFile) {
+    Write-Host "Reading $path"
+    $manifests += Read-CheckManifest $path
+}
+
+foreach ($manifest in $manifests) {
+    Write-Host "Checking $($manifest.Name)..."
+    Test-SdkVersion $manifest
+    Test-Workload $manifest
+    Test-ToolVersion $manifest $repositoryVersion
+    if (-not $SkipUrlCheck) { Test-ManifestUrl $manifest }
+}
+
+$stable = $manifests | Where-Object { $_.Name -eq 'uno.ui' } | Select-Object -First 1
+$preview = $manifests | Where-Object { $_.Name -eq 'uno.ui-preview' } | Select-Object -First 1
+if (-not $SkipAdvisory) {
+    Test-ChannelOverlap $stable $preview
+    Test-Advisory $manifests
+}
+
+if (-not $SkipGitCheck) { Test-ReleasePending $RepositoryRoot $ReleaseGraceDays }
+
+$report = New-Report $script:Findings $repositoryVersion
+
+Write-Host ''
+Write-Host "Action items: $($report.ActionCount) | Advisories: $($report.AdvisoryCount) | Fingerprint: $($report.Fingerprint)"
+Write-Host ''
+Write-Host $report.Markdown
+
+if ($JsonOut) {
+    $report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $JsonOut -Encoding utf8
+    Write-Host "Wrote $JsonOut"
+}
+
+if ($MarkdownOut) {
+    $report.Markdown | Set-Content -LiteralPath $MarkdownOut -Encoding utf8
+    Write-Host "Wrote $MarkdownOut"
+}
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    "## Manifest drift`n`n$($report.Markdown)" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+}
+
+if ($env:GITHUB_OUTPUT) {
+    "has_action=$($report.HasAction.ToString().ToLowerInvariant())" | Add-Content -LiteralPath $env:GITHUB_OUTPUT
+    "action_count=$($report.ActionCount)" | Add-Content -LiteralPath $env:GITHUB_OUTPUT
+    "fingerprint=$($report.Fingerprint)" | Add-Content -LiteralPath $env:GITHUB_OUTPUT
+}
+
+if ($FailOnAction -and $report.HasAction) { exit 2 }
+exit 0

--- a/.github/scripts/Check-ManifestDrift.ps1
+++ b/.github/scripts/Check-ManifestDrift.ps1
@@ -818,7 +818,7 @@ function New-Report {
     [void] $body.AppendLine('---')
     [void] $body.AppendLine("Repository version: ``$RepositoryVersion`` · Checked $([datetimeoffset]::UtcNow.ToString('yyyy-MM-dd HH:mm')) UTC")
 
-    $fingerprintSource = ($actions | ForEach-Object { '{0}|{1}|{2}|{3}' -f $_.Kind, $_.Manifest, $_.Subject, $_.Latest } | Sort-Object) -join "`n"
+    $fingerprintSource = ($actions | ForEach-Object { '{0}|{1}|{2}|{3}|{4}' -f $_.Kind, $_.Manifest, $_.Subject, $_.Current, $_.Latest } | Sort-Object) -join "`n"
     $hash = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($fingerprintSource))
     $fingerprint = ([System.BitConverter]::ToString($hash) -replace '-', '').Substring(0, 16).ToLowerInvariant()
 

--- a/.github/scripts/Sync-DriftIssue.ps1
+++ b/.github/scripts/Sync-DriftIssue.ps1
@@ -1,0 +1,200 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Turns a manifest drift report into a single, self-maintaining GitHub tracking issue.
+
+.DESCRIPTION
+    Idempotent by design, so a daily schedule does not create noise:
+      * no drift, no issue      -> nothing happens
+      * drift, no issue         -> opens one
+      * drift, issue exists     -> refreshes the body in place; comments ONLY when the
+                                   set of action items actually changed, listing what is
+                                   new and what went away
+      * drift resolved          -> comments and closes the issue
+
+    The previous state is carried in a base64 HTML comment inside the issue body, so no
+    external storage is needed.
+
+.PARAMETER DryRun
+    Prints what would happen and writes the rendered body to disk. Makes no gh calls.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $ReportPath,
+    [string] $Repository = $env:GITHUB_REPOSITORY,
+    [string] $Label = 'manifest-drift',
+    [string] $Title = 'Manifest drift: pinned .NET SDK / workloads are behind upstream',
+    [string[]] $Assignee,
+    [string] $RunUrl,
+    [string] $BodyOut,
+    [switch] $DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$marker = '<!-- uno-check-manifest-drift -->'
+
+function Get-ActionKey {
+    param($Finding)
+    '{0}|{1}|{2}|{3}' -f $Finding.Kind, $Finding.Manifest, $Finding.Subject, $Finding.Latest
+}
+
+function ConvertTo-StateComment {
+    param([string[]] $Keys)
+    $json = ($Keys | Sort-Object) | ConvertTo-Json -Compress -AsArray
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+    "<!-- state:$encoded -->"
+}
+
+function ConvertFrom-StateComment {
+    param([string] $Body)
+    if (-not $Body -or $Body -notmatch '<!-- state:([A-Za-z0-9+/=]+) -->') { return @() }
+    try {
+        $json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($Matches[1]))
+        return @($json | ConvertFrom-Json)
+    }
+    catch {
+        return @()
+    }
+}
+
+function Invoke-Gh {
+    param([string[]] $Arguments)
+
+    if ($DryRun) {
+        Write-Host "[dry-run] gh $($Arguments -join ' ')" -ForegroundColor DarkGray
+        return ''
+    }
+
+    # Keep stdout clean: gh writes progress/warnings to stderr, and mixing them in would
+    # corrupt the JSON that callers parse from `gh issue list`.
+    $stdout = [System.Collections.Generic.List[string]]::new()
+    $stderr = [System.Collections.Generic.List[string]]::new()
+    & gh @Arguments 2>&1 | ForEach-Object {
+        if ($_ -is [System.Management.Automation.ErrorRecord]) { $stderr.Add([string] $_) }
+        else { $stdout.Add([string] $_) }
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh $($Arguments -join ' ') failed: $((@($stderr) + @($stdout)) -join "`n")"
+    }
+    return ($stdout -join "`n")
+}
+
+# ---------------------------------------------------------------------------
+
+$report = Get-Content -LiteralPath $ReportPath -Raw | ConvertFrom-Json
+$actions = @($report.Findings | Where-Object { $_.Tier -eq 'Action' })
+$currentKeys = @($actions | ForEach-Object { Get-ActionKey $_ })
+
+if (-not $RunUrl -and $env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_RUN_ID) {
+    $RunUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+}
+
+$body = @(
+    $marker
+    (ConvertTo-StateComment $currentKeys)
+    ''
+    'This issue is maintained automatically by the `manifest-drift` workflow. It is refreshed in place on every run and closes itself once the drift is gone.'
+    ''
+    $report.Markdown
+    ''
+    $(if ($RunUrl) { "[Latest run]($RunUrl)" } else { '' })
+) -join "`n"
+
+if ($BodyOut) {
+    $body | Set-Content -LiteralPath $BodyOut -Encoding utf8
+    Write-Host "Wrote $BodyOut"
+}
+
+# Locate the tracking issue, if any.
+$existing = $null
+if (-not $DryRun) {
+    $listed = Invoke-Gh @('issue', 'list', '--repo', $Repository, '--label', $Label, '--state', 'open',
+        '--json', 'number,body,title', '--limit', '50')
+    if ($listed) {
+        $existing = @($listed | ConvertFrom-Json) | Where-Object { $_.body -and $_.body.Contains($marker) } | Select-Object -First 1
+    }
+}
+else {
+    Write-Host '[dry-run] would search for an existing tracking issue' -ForegroundColor DarkGray
+}
+
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) "drift-body-$([guid]::NewGuid()).md"
+$body | Set-Content -LiteralPath $bodyFile -Encoding utf8
+
+try {
+    if ($actions.Count -eq 0) {
+        if ($existing) {
+            $comment = "All previously reported manifest drift is resolved as of this run. Closing.`n`n" +
+            $(if ($RunUrl) { "[Run]($RunUrl)" } else { '' })
+            Invoke-Gh @('issue', 'comment', "$($existing.number)", '--repo', $Repository, '--body', $comment) | Out-Null
+            Invoke-Gh @('issue', 'close', "$($existing.number)", '--repo', $Repository, '--reason', 'completed') | Out-Null
+            Write-Host "Closed issue #$($existing.number) - no drift remaining."
+        }
+        else {
+            Write-Host 'No drift and no open tracking issue. Nothing to do.'
+        }
+
+        if ($env:GITHUB_OUTPUT) { "issue_action=none" | Add-Content -LiteralPath $env:GITHUB_OUTPUT }
+        return
+    }
+
+    if (-not $existing) {
+        # Label may not exist yet; creating it is best-effort.
+        try {
+            Invoke-Gh @('label', 'create', $Label, '--repo', $Repository, '--color', 'EDB219',
+                '--description', 'Pinned SDK/workload versions are behind upstream', '--force') | Out-Null
+        }
+        catch {
+            Write-Warning "Could not ensure label '$Label': $($_.Exception.Message)"
+        }
+
+        $arguments = @('issue', 'create', '--repo', $Repository, '--title', $Title, '--label', $Label, '--body-file', $bodyFile)
+        foreach ($person in ($Assignee ?? @())) {
+            if ($person) { $arguments += @('--assignee', $person) }
+        }
+
+        $created = Invoke-Gh $arguments
+        Write-Host "Opened tracking issue: $created"
+
+        if ($env:GITHUB_OUTPUT) { "issue_action=created" | Add-Content -LiteralPath $env:GITHUB_OUTPUT }
+        return
+    }
+
+    $previousKeys = ConvertFrom-StateComment $existing.body
+    $added = @($currentKeys | Where-Object { $_ -notin $previousKeys })
+    $removed = @($previousKeys | Where-Object { $_ -notin $currentKeys })
+
+    Invoke-Gh @('issue', 'edit', "$($existing.number)", '--repo', $Repository, '--body-file', $bodyFile) | Out-Null
+
+    if ($added.Count -eq 0 -and $removed.Count -eq 0) {
+        Write-Host "Issue #$($existing.number) refreshed; drift set unchanged, so no comment was added."
+        if ($env:GITHUB_OUTPUT) { "issue_action=refreshed" | Add-Content -LiteralPath $env:GITHUB_OUTPUT }
+        return
+    }
+
+    $lines = @('The drift set changed since the last run.', '')
+    if ($added.Count -gt 0) {
+        $lines += '**New:**'
+        $lines += ($added | ForEach-Object { "- ``$_``" })
+        $lines += ''
+    }
+    if ($removed.Count -gt 0) {
+        $lines += '**No longer reported:**'
+        $lines += ($removed | ForEach-Object { "- ``$_``" })
+        $lines += ''
+    }
+    if ($RunUrl) { $lines += "[Run]($RunUrl)" }
+
+    Invoke-Gh @('issue', 'comment', "$($existing.number)", '--repo', $Repository, '--body', ($lines -join "`n")) | Out-Null
+    Write-Host "Issue #$($existing.number) updated: $($added.Count) new, $($removed.Count) resolved."
+
+    if ($env:GITHUB_OUTPUT) { "issue_action=updated" | Add-Content -LiteralPath $env:GITHUB_OUTPUT }
+}
+finally {
+    Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+}

--- a/.github/scripts/Sync-DriftIssue.ps1
+++ b/.github/scripts/Sync-DriftIssue.ps1
@@ -39,7 +39,7 @@ $marker = '<!-- uno-check-manifest-drift -->'
 
 function Get-ActionKey {
     param($Finding)
-    '{0}|{1}|{2}|{3}' -f $Finding.Kind, $Finding.Manifest, $Finding.Subject, $Finding.Latest
+    '{0}|{1}|{2}|{3}|{4}' -f $Finding.Kind, $Finding.Manifest, $Finding.Subject, $Finding.Current, $Finding.Latest
 }
 
 function ConvertTo-StateComment {

--- a/.github/scripts/Sync-DriftIssue.ps1
+++ b/.github/scripts/Sync-DriftIssue.ps1
@@ -44,7 +44,11 @@ function Get-ActionKey {
 
 function ConvertTo-StateComment {
     param([string[]] $Keys)
-    $json = ($Keys | Sort-Object) | ConvertTo-Json -Compress -AsArray
+    # ConvertTo-Json returns $null - not '[]' - for an empty pipeline, even with -AsArray.
+    # Every no-drift run has an empty key set, so without this the resolved/close path dies
+    # in GetBytes() before it can reach a single gh call.
+    $json = (@($Keys) | Sort-Object) | ConvertTo-Json -Compress -AsArray
+    if ($null -eq $json) { $json = '[]' }
     $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
     "<!-- state:$encoded -->"
 }
@@ -90,6 +94,10 @@ $report = Get-Content -LiteralPath $ReportPath -Raw | ConvertFrom-Json
 $actions = @($report.Findings | Where-Object { $_.Tier -eq 'Action' })
 $currentKeys = @($actions | ForEach-Object { Get-ActionKey $_ })
 
+# Read defensively: a report written by an older checker has no such field, and under
+# StrictMode a bare property access on it would terminate.
+$degraded = [bool] ($report.PSObject.Properties['SourcesDegraded'] -and $report.SourcesDegraded)
+
 if (-not $RunUrl -and $env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_RUN_ID) {
     $RunUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
 }
@@ -128,6 +136,17 @@ $body | Set-Content -LiteralPath $bodyFile -Encoding utf8
 
 try {
     if ($actions.Count -eq 0) {
+        if ($existing -and $degraded) {
+            # Zero actions because a feed was unreachable is not "resolved". Closing here
+            # would post a false all-clear and then re-open a fresh issue on the next good
+            # run, losing the thread, its assignees and its history. Leave the issue
+            # untouched - editing the body would also overwrite the stored state and make
+            # every still-open item look new tomorrow.
+            Write-Host "Issue #$($existing.number) left as-is: $($report.DegradedCount) check(s) could not be completed, so drift is unproven this run."
+            if ($env:GITHUB_OUTPUT) { "issue_action=held" | Add-Content -LiteralPath $env:GITHUB_OUTPUT }
+            return
+        }
+
         if ($existing) {
             $comment = "All previously reported manifest drift is resolved as of this run. Closing.`n`n" +
             $(if ($RunUrl) { "[Run]($RunUrl)" } else { '' })

--- a/.github/workflows/manifest-drift.yml
+++ b/.github/workflows/manifest-drift.yml
@@ -31,19 +31,27 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: manifest-drift
   cancel-in-progress: false
 
 jobs:
+  # The detector runs PR-authored code (the pull_request trigger above deliberately covers
+  # the scripts themselves), so this job stays unprivileged: read-only token, no secrets in
+  # scope, credentials not persisted into .git/config. Everything that needs write access
+  # lives in the `report` job below, which never runs on a pull request.
   drift:
     name: Check manifest drift
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-    env:
-      MANIFEST_DRIFT_WEBHOOK: ${{ secrets.MANIFEST_DRIFT_WEBHOOK }}
+    permissions:
+      contents: read
+
+    outputs:
+      has_action: ${{ steps.drift.outputs.has_action }}
+      action_count: ${{ steps.drift.outputs.action_count }}
 
     steps:
       - name: Checkout
@@ -51,6 +59,7 @@ jobs:
         with:
           # Tags and full history are required by the release-pending check.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Self-test the detector
         shell: pwsh
@@ -74,12 +83,47 @@ jobs:
             drift.md
           if-no-files-found: warn
 
-      # On pull requests the summary is the deliverable - never touch the tracking issue.
+  # On pull requests the step summary is the deliverable - never touch the tracking issue.
+  # `has_action != ''` means the detector got far enough to publish its outputs, so this
+  # job still runs after a deliberate -FailOnAction exit, but not after a crash that left
+  # no report to sync.
+  report:
+    name: Sync tracking issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: drift
+    if: >-
+      ${{ !cancelled()
+      && github.event_name != 'pull_request'
+      && inputs.skip_issue != true
+      && needs.drift.outputs.has_action != '' }}
+
+    permissions:
+      contents: read
+      issues: write
+
+    # Job-scoped rather than workflow-scoped: this job cannot be reached by a pull request,
+    # so the secret is never in the environment of a step running PR-authored script code.
+    env:
+      MANIFEST_DRIFT_WEBHOOK: ${{ secrets.MANIFEST_DRIFT_WEBHOOK }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download report
+        uses: actions/download-artifact@v4
+        with:
+          name: manifest-drift-report
+
       - name: Sync tracking issue
-        if: ${{ github.event_name != 'pull_request' && inputs.skip_issue != true }}
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Via env, never interpolated into the script body: a repo variable is set in
+          # settings rather than reviewed as code, and an apostrophe in the value would
+          # otherwise close the PowerShell literal and run whatever followed it.
+          ASSIGNEES: ${{ vars.MANIFEST_DRIFT_ASSIGNEES }}
         run: |
           # Hashtable splatting keeps -Assignee a real string[]; array splatting would
           # flatten it and a second assignee would fail parameter binding.
@@ -87,17 +131,17 @@ jobs:
             ReportPath = 'drift.json'
             Repository = '${{ github.repository }}'
           }
-          $assignees = @('${{ vars.MANIFEST_DRIFT_ASSIGNEES }}' -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+          $assignees = @($env:ASSIGNEES -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
           if ($assignees.Count -gt 0) { $params.Assignee = $assignees }
           ./.github/scripts/Sync-DriftIssue.ps1 @params
 
       # Optional out-of-band alarm. No-ops unless the MANIFEST_DRIFT_WEBHOOK secret is set.
       - name: Notify webhook
-        if: ${{ github.event_name != 'pull_request' && steps.drift.outputs.has_action == 'true' && env.MANIFEST_DRIFT_WEBHOOK != '' }}
+        if: ${{ needs.drift.outputs.has_action == 'true' && env.MANIFEST_DRIFT_WEBHOOK != '' }}
         shell: pwsh
         run: |
           $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           $payload = @{
-            content = ":rotating_light: **uno.check manifest drift** - ${{ steps.drift.outputs.action_count }} action item(s) need attention. See the ``manifest-drift`` tracking issue or the [run]($runUrl)."
+            content = ":rotating_light: **uno.check manifest drift** - ${{ needs.drift.outputs.action_count }} action item(s) need attention. See the ``manifest-drift`` tracking issue or the [run]($runUrl)."
           } | ConvertTo-Json -Compress
           Invoke-RestMethod -Uri $env:MANIFEST_DRIFT_WEBHOOK -Method Post -ContentType 'application/json' -Body $payload -TimeoutSec 30

--- a/.github/workflows/manifest-drift.yml
+++ b/.github/workflows/manifest-drift.yml
@@ -1,0 +1,103 @@
+name: Manifest Drift
+
+# The manifests are embedded resources in the Uno.Check package, so a manifest change only
+# reaches users once a new package is published. This job watches the upstream release trains
+# that drive those manifests and keeps a single tracking issue in sync with what it finds.
+
+on:
+  schedule:
+    # Daily. Microsoft's servicing releases (Patch Tuesday) land during US business hours,
+    # so an early-UTC run picks them up the following morning.
+    - cron: '0 7 * * *'
+
+  workflow_dispatch:
+    inputs:
+      fail_on_action:
+        description: 'Fail the job when action items are found'
+        type: boolean
+        default: false
+      skip_issue:
+        description: 'Report only, do not create or update the tracking issue'
+        type: boolean
+        default: false
+
+  # Keep the checker honest: run it on PRs that touch the manifests or the scripts themselves.
+  pull_request:
+    paths:
+      - 'manifests/**'
+      - '.github/scripts/Check-ManifestDrift.ps1'
+      - '.github/scripts/Sync-DriftIssue.ps1'
+      - '.github/workflows/manifest-drift.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: manifest-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: Check manifest drift
+    runs-on: ubuntu-latest
+
+    env:
+      MANIFEST_DRIFT_WEBHOOK: ${{ secrets.MANIFEST_DRIFT_WEBHOOK }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Tags and full history are required by the release-pending check.
+          fetch-depth: 0
+
+      - name: Self-test the detector
+        shell: pwsh
+        run: ./.github/scripts/Check-ManifestDrift.ps1 -SelfTest
+
+      - name: Check for drift
+        id: drift
+        shell: pwsh
+        run: |
+          $arguments = @('-JsonOut', 'drift.json', '-MarkdownOut', 'drift.md')
+          if ('${{ inputs.fail_on_action }}' -eq 'true') { $arguments += '-FailOnAction' }
+          ./.github/scripts/Check-ManifestDrift.ps1 @arguments
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest-drift-report
+          path: |
+            drift.json
+            drift.md
+          if-no-files-found: warn
+
+      # On pull requests the summary is the deliverable - never touch the tracking issue.
+      - name: Sync tracking issue
+        if: ${{ github.event_name != 'pull_request' && inputs.skip_issue != true }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Hashtable splatting keeps -Assignee a real string[]; array splatting would
+          # flatten it and a second assignee would fail parameter binding.
+          $params = @{
+            ReportPath = 'drift.json'
+            Repository = '${{ github.repository }}'
+          }
+          $assignees = @('${{ vars.MANIFEST_DRIFT_ASSIGNEES }}' -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+          if ($assignees.Count -gt 0) { $params.Assignee = $assignees }
+          ./.github/scripts/Sync-DriftIssue.ps1 @params
+
+      # Optional out-of-band alarm. No-ops unless the MANIFEST_DRIFT_WEBHOOK secret is set.
+      - name: Notify webhook
+        if: ${{ github.event_name != 'pull_request' && steps.drift.outputs.has_action == 'true' && env.MANIFEST_DRIFT_WEBHOOK != '' }}
+        shell: pwsh
+        run: |
+          $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          $payload = @{
+            content = ":rotating_light: **uno.check manifest drift** - ${{ steps.drift.outputs.action_count }} action item(s) need attention. See the ``manifest-drift`` tracking issue or the [run]($runUrl)."
+          } | ConvertTo-Json -Compress
+          Invoke-RestMethod -Uri $env:MANIFEST_DRIFT_WEBHOOK -Method Post -ContentType 'application/json' -Body $payload -TimeoutSec 30

--- a/.github/workflows/manifest-drift.yml
+++ b/.github/workflows/manifest-drift.yml
@@ -69,9 +69,15 @@ jobs:
         id: drift
         shell: pwsh
         run: |
-          $arguments = @('-JsonOut', 'drift.json', '-MarkdownOut', 'drift.md')
-          if ('${{ inputs.fail_on_action }}' -eq 'true') { $arguments += '-FailOnAction' }
-          ./.github/scripts/Check-ManifestDrift.ps1 @arguments
+          # Hashtable splatting, not an array: an array splat binds positionally, so
+          # '-JsonOut' lands in $RepositoryRoot and 'drift.json' in $ManifestFile - the
+          # checker then tries to parse its own output file as a manifest.
+          $params = @{
+            JsonOut     = 'drift.json'
+            MarkdownOut = 'drift.md'
+          }
+          if ('${{ inputs.fail_on_action }}' -eq 'true') { $params.FailOnAction = $true }
+          ./.github/scripts/Check-ManifestDrift.ps1 @params
 
       - name: Upload report
         if: always()

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -2,22 +2,27 @@
 
 These are used by the tool to parse up-to-date versions and information on which things to validate and install.
 
+They are **embedded resources** in the `Uno.Check` package (see `UnoCheck/UnoCheck.csproj`), so a manifest
+change does not reach users until a new package is published to NuGet.
+
 They are grouped into the following channels:
 
-### Default
-This should align with the current MAUI stable version available:
-- maui.manifest.json
-- https://aka.ms/dotnet-maui-check-manifest
+### Default (stable)
+Used when no channel flag is passed. Should align with the current stable .NET SDK and workloads:
+- `uno.ui.manifest.json`
 
 ### Preview
-This should align with the current MAUI preview version available:
-- maui-preview.manifest.json
-- https://aka.ms/dotnet-maui-check-manifest-preview
+Used with `--pre` / `--preview`. Tracks in-band previews of the current .NET major:
+- `uno.ui-preview.manifest.json`
+
+### Preview major
+Used with `--pre-major` / `--preview-major`. Tracks previews of the *next* .NET major:
+- `uno.ui-preview-major.manifest.json`
 
 ### Main
-This should align with the current MAUI main branch version available and will change often:
-- maui-main.manifest.json
-- https://aka.ms/dotnet-maui-check-manifest-main
+Used with `--main` / `--dev-manifest`. This is the only channel that is **not** embedded: it is fetched at
+runtime from `main`, so changes take effect without a tool release.
+- https://raw.githubusercontent.com/unoplatform/uno.check/main/manifests/uno.ui.manifest.json
 
 ## Updating the Manifest
 
@@ -33,3 +38,63 @@ To update the manifest, the usual process is:
    dotnet workload list
    ```
 4. Use the output to update the manifest with the correct versions.
+
+Transcribe the **Manifest Version** column verbatim, including the `version/band` form
+(for example `36.1.43/10.0.100`). Values live in the `check.variables` block; the workload
+entries reference them as `$(ANDROID_SDK_VERSION)` and friends.
+
+See `AGENTS.md` section 5 for the full procedure.
+
+## After updating: cut a release
+
+Merging a manifest change to `main` publishes a `-dev` prerelease only. Users keep getting the versions
+from the last stable release until a `release/stable/X.Y` branch is pushed, which triggers the production
+publish and tags the release.
+
+## Automated drift detection
+
+`.github/workflows/manifest-drift.yml` runs daily and reports when these manifests have fallen behind
+upstream, or when manifest changes are waiting on a release.
+
+| Check | Tier | Meaning |
+| --- | --- | --- |
+| `sdk-servicing` | Action | A newer .NET SDK exists in the pinned feature band |
+| `sdk-band-move` | Advisory | A newer feature band exists; moving is a deliberate call |
+| `workload` | Action | A newer workload manifest package is published |
+| `workload-unknown-package` | Action | The `packageId` matches nothing on the configured feeds, so that workload is not being drift-checked |
+| `url-dead` | Action | A download URL in the manifest no longer resolves |
+| `release-pending` | Action after 7 days | Manifest commits on `main` are not in a stable release yet |
+| `tool-version` | Action | `check.toolVersion` requires a tool newer than `version.json` |
+| `channel-overlap` | Advisory | The preview manifest pins the same versions as stable |
+| `xcode`, `openjdk` | Advisory | Newer releases exist; raising the minimum is a policy decision |
+| `manifest-parse` | Advisory | A pinned version could not be parsed, so it is not being drift-checked |
+| `source-offline` | Advisory | A data source was unreachable, so its checks are unproven this run |
+
+Findings are collected into **one** tracking issue labelled `manifest-drift`. It is refreshed in place on
+every run, comments only when the set of action items actually changes, and closes itself once the drift
+is gone.
+
+**The reported "Available" versions are a signal, not a validated set.** Always confirm on a clean machine
+with `dotnet workload list` before editing a manifest — the checker reads package feeds, which include
+builds that were never part of a shipped SDK.
+
+### Running it locally
+
+```pwsh
+# Offline unit tests for the version/band comparison helpers
+./.github/scripts/Check-ManifestDrift.ps1 -SelfTest
+
+# Full check (network); add -SkipUrlCheck for a faster run
+./.github/scripts/Check-ManifestDrift.ps1 -JsonOut drift.json -MarkdownOut drift.md
+
+# Render the tracking issue body without touching GitHub
+./.github/scripts/Sync-DriftIssue.ps1 -ReportPath drift.json -BodyOut body.md -DryRun
+```
+
+### Configuration
+
+| Setting | Where | Effect |
+| --- | --- | --- |
+| `MANIFEST_DRIFT_ASSIGNEES` | repository variable | Comma-separated logins assigned to a newly opened issue |
+| `MANIFEST_DRIFT_WEBHOOK` | repository secret | Optional Discord-style webhook pinged when action items exist |
+| `-ReleaseGraceDays` | script parameter | Days a manifest change may sit unreleased before it becomes an Action (default 7) |

--- a/manifests/uno.ui-preview.manifest.json
+++ b/manifests/uno.ui-preview.manifest.json
@@ -142,7 +142,7 @@
             {
               "workloadId": "wasm-tools",
               "workloadManifestId": "microsoft.net.workload.mono.toolchain.current",
-              "packageId": "Microsoft.NET.Workload.Mono.ToolChain.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest-10.0.100",
               "version": "$(WASMTOOLS_VERSION)",
               "supportedPlatforms": [ "Windows", "OSX", "Linux/x64", "Linux/arm64" ]
             }

--- a/manifests/uno.ui.manifest.json
+++ b/manifests/uno.ui.manifest.json
@@ -142,7 +142,7 @@
             {
               "workloadId": "wasm-tools",
               "workloadManifestId": "microsoft.net.workload.mono.toolchain.current",
-              "packageId": "Microsoft.NET.Workload.Mono.ToolChain.Manifest-10.0.100",
+              "packageId": "Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest-10.0.100",
               "version": "$(WASMTOOLS_VERSION)",
               "supportedPlatforms": [ "Windows", "OSX", "Linux/x64", "Linux/arm64" ]
             }

--- a/specs/002-manifest-drift-automation/spec.md
+++ b/specs/002-manifest-drift-automation/spec.md
@@ -1,0 +1,242 @@
+# uno-check: Manifest Drift Detection & Release-Pending Automation
+
+## Overview & Objectives
+
+The three manifests under `manifests/` (`uno.ui`, `uno.ui-preview`, `uno.ui-preview-major`)
+are **embedded resources** in the `Uno.Check` NuGet package (`UnoCheck/UnoCheck.csproj`).
+Two consequences drive this spec:
+
+1. A manifest edit reaches nobody until a new package ships — merging to `main` only
+   publishes a `-dev` prerelease; users on the stable tool keep the pins from the last
+   `release/stable/X.Y` release.
+2. The pinned versions track release trains that Uno does not control: the .NET SDK
+   servicing schedule (Patch Tuesday), workload manifest packages (Android/iOS/tvOS/
+   MacCatalyst/MAUI/wasm-tools, each on its own cadence), Xcode, and Microsoft OpenJDK.
+
+Until now, noticing that these had moved — or that manifest commits were sitting on
+`main` unreleased — was a matter of someone remembering to look. When this automation
+first ran against live data it found the pinned Android workload three servicing
+releases behind, iOS bindings a minor version behind, and **nine manifest commits that
+had been unreleased for 157 days**.
+
+### Key objective
+
+A scheduled, zero-maintenance watchdog that:
+
+- detects when any pinned version in any manifest channel has fallen behind its
+  upstream source, or when a pinned download URL has died;
+- detects when manifest changes on `main` are waiting on a stable release;
+- surfaces everything in **one** self-maintaining GitHub issue (plus an optional
+  webhook ping), with enough context that acting on it requires no archaeology;
+- never auto-edits a manifest (see *Non-goals*).
+
+### Non-goals
+
+- **No automatic manifest updates / auto-PRs.** The authoritative source for workload
+  pins is `dotnet workload list` on a clean machine (`AGENTS.md` §5), because package
+  feeds contain builds that were never part of a shipped SDK. The automation reports
+  drift; a human validates and transcribes the real versions.
+- **No paging/alerting infrastructure.** A tracking issue and an optional webhook are
+  the alarm surface. Anything more belongs to whoever consumes the webhook.
+- **No tracking of tool-code (C#) changes pending release** — scope is the manifests.
+  Extending the release-pending check beyond `manifests/` would fire on every docs
+  commit.
+
+---
+
+## Components
+
+| File | Role |
+|------|------|
+| `.github/scripts/Check-ManifestDrift.ps1` | Detector. Pure reporting — reads the manifests, queries upstream sources, emits a tiered findings report (JSON + Markdown + step summary). No side effects. |
+| `.github/scripts/Sync-DriftIssue.ps1` | Reporter. Reconciles the findings report with a single labelled tracking issue via `gh`. Idempotent. |
+| `.github/workflows/manifest-drift.yml` | Orchestration. Daily schedule + `workflow_dispatch` + PR validation runs. |
+| `manifests/README.md` | Operator documentation (channels, release flow, check catalogue, local usage). |
+
+### Detector checks
+
+| Kind | Tier | Source | Meaning |
+|------|------|--------|---------|
+| `sdk-servicing` | Action | `builds.dotnet.microsoft.com` release metadata | A newer .NET SDK exists **within the pinned feature band** |
+| `sdk-band-move` | Advisory | same | A newer feature band exists for the pinned channel |
+| `workload` | Action | NuGet flat-container, per manifest `packageSources` | A newer workload manifest package is published |
+| `workload-unknown-package` | Action | same | The `packageId` matches nothing on any configured feed, so that workload cannot be drift-checked |
+| `url-dead` | Action | HTTP probe of every `urls.*` entry | A pinned download URL no longer resolves |
+| `release-pending` | Advisory → Action after grace (default 7 days) | git tags vs `origin/main` | Manifest commits newer than the latest stable tag are not in any stable release |
+| `tool-version` | Action | `version.json` vs `check.toolVersion` | The manifest demands a tool version no release can satisfy (or omits it, which aborts `--ci` runs) |
+| `channel-overlap` | Advisory | manifest comparison | Preview pins are identical to stable — `--pre` offers users nothing |
+| `xcode` | Advisory | `xcodereleases.com` | A newer Xcode GA exists (raising `minimumVersion` is a policy decision) |
+| `openjdk` | Advisory | Adoptium API + `aka.ms` probe | A newer JDK of the pinned major exists **and** Microsoft has published its installer |
+| `manifest-parse` | Advisory | local | A pinned value could not be parsed, so it is not being drift-checked |
+| `source-offline` | Advisory | local | An upstream source was unreachable — the affected checks are unproven this run, not passing |
+
+---
+
+## Design decisions
+
+### 1. Signal, not autofix
+
+The "Available" column in a finding is a drift signal read from package feeds. Feeds
+carry builds that never shipped in an SDK, and the `version/band` pairs in the manifest
+are the .NET workload resolver's own output, not free-choice values. The report says so
+explicitly and points at the `AGENTS.md` §5 clean-machine procedure. This mirrors how
+the manifests have always been updated; the automation removes the *noticing* burden,
+not the *validation* step.
+
+### 2. Two tiers, so the alarm stays credible
+
+Every finding is either **Action** (something in this repository must change) or
+**Advisory** (a judgement call, or a degraded-confidence note). Only Action items feed
+the issue-change detection and the webhook. Mixing "Android bindings are 3 releases
+behind" with "a new Xcode exists somewhere" is how watchdogs get muted.
+
+Two tier rules worth calling out:
+
+- **In-band servicing is Action; a feature-band move is Advisory.** The tool's SDK check
+  is `>=` (`DotNetCheckup.cs`), but moving bands rewrites every workload `packageId`
+  suffix and the band half of every workload pin — a deliberate, verify-on-clean-machine
+  decision.
+- **Stable channels only chase nuget.org-visible versions.** A version that exists only
+  on a `dnceng` build feed is downgraded to Advisory for stable manifests (possibly an
+  unreleased build); preview channels keep it as Action, since previews legitimately
+  consume the dotnet build feeds first.
+
+### 3. One self-maintaining issue, state carried in-band
+
+`Sync-DriftIssue.ps1` maintains a single issue labelled `manifest-drift`:
+
+- no drift, no issue → no-op;
+- drift, no issue → open one (label auto-created, optional assignees);
+- drift, issue exists → **edit the body in place**; comment *only when the Action set
+  actually changed*, listing what is new and what resolved;
+- drift gone → comment and close.
+
+The previous Action set rides inside the issue body as a base64-encoded HTML comment,
+so change detection needs no external storage, survives runner recycling, and cannot
+desync from what the issue displays. A daily schedule therefore produces zero
+notifications on quiet days.
+
+### 4. Feeds are resolved the way the tool resolves them
+
+Workload packages are queried against **each manifest's own `packageSources`** (Azure
+DevOps service index resolved to its flat-container base URL, nuget.org fallback), so
+the checker sees what `uno-check --fix` would see. Which feed served each version is
+recorded, feeding the stable-vs-build-feed tier rule above.
+
+### 5. Fail-safe posture: a broken checker must not read as "no drift"
+
+- The detector runs its **offline self-test suite (24 assertions** on SemVer2
+  comparison, feature-band math, variable resolution, and safe property access**)
+  before every real run** and refuses to report if it fails. The workflow also runs it
+  as a dedicated step.
+- Unreachable sources produce `source-offline` findings instead of silently passing.
+- Manifest traversal uses StrictMode-safe accessors (`Get-Prop`), so a future manifest
+  shape degrades to "nothing to check for this node" rather than crashing.
+- The workflow also triggers on PRs touching `manifests/**` or the automation itself,
+  so script regressions surface at review time, not at 07:00 UTC.
+
+### 6. Release-pending accounting
+
+`git log <latest-stable-tag>..origin/main -- manifests/` (tags matching `^\d+\.\d+(\.\d+)?$`,
+version-sorted). Advisory for the first `-ReleaseGraceDays` (default 7) so normal
+merge-then-release flow doesn't alarm; Action after that. Requires `fetch-depth: 0`.
+
+Known edge: commits cherry-picked onto a `release/stable/*` branch keep different SHAs
+and still count as pending. Accepted — manifest cherry-picks are rare, and the finding
+text lists the commits so the situation is recognizable at a glance.
+
+### 7. Advisory-only external trains
+
+Xcode and OpenJDK minimums are policy (raising the Xcode floor before the matching
+iOS/tvOS/MacCatalyst bindings are pinned would tell macOS users to upgrade for
+workloads that don't exist). The OpenJDK check derives the major from each manifest's
+`OPENJDK_VERSION` (no hardcoded "17"), and only reports a version whose Microsoft
+installer actually exists (probed via the same `aka.ms` URL pattern the manifest uses).
+
+---
+
+## Included manifest fix: wasm-tools `packageId`
+
+`uno.ui.manifest.json` and `uno.ui-preview.manifest.json` pinned wasm-tools to
+`packageId: Microsoft.NET.Workload.Mono.ToolChain.Manifest-10.0.100`, which does not
+exist on nuget.org or the dnceng dotnet10 feed (both 404). The real package is
+`Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest-10.0.100` (both 200);
+`uno.ui-preview-major` already used the `.Current.` form, and the functionally-matched
+field `workloadManifestId` (`microsoft.net.workload.mono.toolchain.current`) was already
+correct in all three.
+
+Impact assessment: in the tool, `PackageId` is only interpolated into the not-installed
+diagnostic message (`UnoCheck/Checkups/DotNetWorkloadsCheckup.cs`), so installs were
+never broken — but the wrong id made wasm-tools invisible to this drift checker (a
+guaranteed `workload-unknown-package` finding). Fixed here (one line per manifest) so
+the automation covers all seven workloads from day one; after the fix the checker
+immediately reported real wasm drift (`10.0.105` → `10.0.110`), confirming coverage.
+
+---
+
+## Operations
+
+### Configuration
+
+| Setting | Where | Effect |
+|---------|-------|--------|
+| `MANIFEST_DRIFT_ASSIGNEES` | repository variable | Comma-separated logins assigned when the issue is first opened |
+| `MANIFEST_DRIFT_WEBHOOK` | repository secret | Optional webhook (Discord-style JSON) pinged when Action items exist; absent = no-op |
+| `-ReleaseGraceDays` | script parameter | Days manifest commits may sit unreleased before becoming Action (default 7) |
+
+Workflow permissions: `contents: read`, `issues: write`. On `pull_request` events the
+issue-sync and webhook steps are skipped (summary + artifact only), so fork PRs with
+read-only tokens work.
+
+### Local usage
+
+```pwsh
+# Offline unit tests only
+./.github/scripts/Check-ManifestDrift.ps1 -SelfTest
+
+# Full check (network; ~2 min). -SkipUrlCheck / -SkipAdvisory / -SkipGitCheck to narrow.
+./.github/scripts/Check-ManifestDrift.ps1 -JsonOut drift.json -MarkdownOut drift.md
+
+# Render the would-be issue body without touching GitHub
+./.github/scripts/Sync-DriftIssue.ps1 -ReportPath drift.json -BodyOut body.md -DryRun
+```
+
+### First-run expectation
+
+The first scheduled run will open the tracking issue with the currently-true drift
+(at authoring time: 17 Action items — SDK `10.0.201`→`10.0.204` in-band, all six
+platform workloads behind, .NET 11 preview-major one preview behind, and the
+release-pending backlog since `1.34.1`).
+
+---
+
+## Validation
+
+Evidence labels per the debugging-discipline convention:
+
+- **Runtime** — detector self-test: 24/24 passing (offline, no network).
+- **Runtime** — full detector run against live endpoints (release metadata, nuget.org,
+  dnceng, xcodereleases, Adoptium, download URL probes): completes in ~2 min, findings
+  spot-checked against manual `curl` queries of the same feeds; wasm-tools coverage
+  verified before/after the `packageId` fix (`workload-unknown-package` → real
+  `workload` finding).
+- **Runtime** — `Sync-DriftIssue.ps1 -DryRun`: body renders, embedded state
+  round-trips (17 keys decoded), simulated set-change diff labels added/removed
+  correctly, multi-assignee binding produces `--assignee a --assignee b`.
+- **Code review** — workflow YAML parsed; expression edge cases for `inputs.*` on
+  non-dispatch events and empty/whitespace `MANIFEST_DRIFT_ASSIGNEES` exercised locally.
+- **Not exercised** — live `gh issue` create/edit/close against the real repository
+  (would post to the public tracker). First `workflow_dispatch` run shakes this out;
+  the failure mode is a failed workflow step, not a wrong issue.
+
+## Limitations & future work
+
+- Feed-visible ≠ SDK-shipped: a workload version can appear on nuget.org hours before
+  the SDK that resolves it. The clean-machine validation step absorbs this; the report
+  warns against verbatim copying.
+- `ci.yml`'s host SDK (`DOTNET_VERSION`) is not compared against the manifest pins; the
+  two can drift independently. Candidate future check.
+- Xcode data comes from a community-maintained source (`xcodereleases.com`); it is
+  Advisory-only partly for that reason.
+- The `release-pending` check reads tags; a repository cloned without tags reports a
+  `source-offline` advisory rather than failing.


### PR DESCRIPTION
**GitHub Issue:** closes #545

## What

Adds a daily watchdog that detects when the embedded manifests have fallen behind the upstream release trains they pin, or when manifest changes on `main` are waiting on a stable release — and surfaces everything in one self-maintaining tracking issue.

- `.github/scripts/Check-ManifestDrift.ps1` — detector (pure reporting). Checks: SDK servicing within the pinned feature band (Action) vs band moves (Advisory), workload manifest packages resolved through each manifest's own `packageSources`, dead download URLs, `check.toolVersion` vs `version.json`, unreleased manifest commits since the latest stable tag (7-day grace), preview/stable channel overlap, Xcode/OpenJDK advisories. Runs a 24-assertion offline self-test before every report; unreachable sources become `source-offline` findings instead of silent passes.
- `.github/scripts/Sync-DriftIssue.ps1` — reconciles the report with a single `manifest-drift`-labelled issue: opens/refreshes in place, comments **only** when the Action set changes (state embedded in the issue body as a base64 comment), closes itself when drift clears.
- `.github/workflows/manifest-drift.yml` — daily at 07:00 UTC, `workflow_dispatch`, and PR validation runs on `manifests/**` + the automation itself. Optional webhook via `MANIFEST_DRIFT_WEBHOOK` secret; assignees via `MANIFEST_DRIFT_ASSIGNEES` variable.
- `manifests/README.md` — corrects the stale MAUI-era channel list, documents the embedded-resource release constraint and the check catalogue.
- `specs/002-manifest-drift-automation/spec.md` — full design rationale, validation evidence, limitations.

Also includes a one-line manifest fix: stable/preview pinned wasm-tools to `Microsoft.NET.Workload.Mono.ToolChain.Manifest-10.0.100`, which 404s on nuget.org and dnceng (the shipped package is the `.Current.` form, which preview-major already used). `workloadManifestId` was already correct and `packageId` only feeds diagnostic text, so installs were unaffected — but the wrong id made wasm-tools invisible to feed-based drift checking.

## Why

Manifest updates only reach users after a `release/stable/X.Y` release, and noticing that upstream moved has been manual. First live run of this checker found the Android workload 3 servicing releases behind, iOS bindings a minor behind, and 9 manifest commits unreleased for 157 days.

Deliberate non-goal: **no auto-editing of manifests.** Feeds contain builds that never shipped in an SDK; pins must still be validated on a clean machine per `AGENTS.md` §5. The report says so and links the procedure.

## Validation

- **Runtime**: detector self-test 24/24 (offline); full run against live endpoints (~2 min) with findings spot-checked against manual `curl` of the same feeds; wasm coverage verified before/after the packageId fix (`workload-unknown-package` → real `workload` finding `10.0.105` → `10.0.110`).
- **Runtime**: issue-sync dry-run — body renders, embedded state round-trips, set-change diff labels added/removed correctly, multi-assignee binding verified.
- **Not exercised**: live `gh issue` create/edit/close (posts to the public tracker). First `workflow_dispatch` run covers it; failure mode is a red step, not a wrong issue.

Note: the first scheduled run will open the tracking issue with the currently-true drift (17 Action items at time of writing). Setting `MANIFEST_DRIFT_ASSIGNEES` beforehand is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYEqJBa9z3cm4P1dRhJHGV
