### PR TITLE
POC: doctor GUI over the structured JSON contract

### DIFF
--- a/UnoCheck.Gui/App.xaml
+++ b/UnoCheck.Gui/App.xaml
@@ -1,0 +1,14 @@
+<Application
+	x:Class="UnoCheck.Gui.App"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<Application.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+			</ResourceDictionary.MergedDictionaries>
+			<local:NullToCollapsedConverter xmlns:local="using:UnoCheck.Gui" x:Key="NullToCollapsed" />
+			<local:BoolNegationConverter xmlns:local="using:UnoCheck.Gui" x:Key="BoolNegation" />
+		</ResourceDictionary>
+	</Application.Resources>
+</Application>

--- a/UnoCheck.Gui/App.xaml.cs
+++ b/UnoCheck.Gui/App.xaml.cs
@@ -1,0 +1,24 @@
+using Microsoft.UI.Xaml;
+
+namespace UnoCheck.Gui;
+
+public partial class App : Application
+{
+	private Window? _window;
+
+	public App()
+	{
+		this.InitializeComponent();
+	}
+
+	protected override void OnLaunched(LaunchActivatedEventArgs args)
+	{
+		_window = new Window
+		{
+			Title = "uno-check Doctor (POC)",
+		};
+
+		_window.Content = new MainPage();
+		_window.Activate();
+	}
+}

--- a/UnoCheck.Gui/Converters.cs
+++ b/UnoCheck.Gui/Converters.cs
@@ -1,0 +1,24 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace UnoCheck.Gui;
+
+public sealed class NullToCollapsedConverter : IValueConverter
+{
+	public object Convert(object? value, Type targetType, object? parameter, string language)
+		=> value is null || (value is string s && string.IsNullOrEmpty(s))
+			? Visibility.Collapsed
+			: Visibility.Visible;
+
+	public object ConvertBack(object? value, Type targetType, object? parameter, string language)
+		=> throw new NotSupportedException();
+}
+
+public sealed class BoolNegationConverter : IValueConverter
+{
+	public object Convert(object? value, Type targetType, object? parameter, string language)
+		=> value is bool b && !b;
+
+	public object ConvertBack(object? value, Type targetType, object? parameter, string language)
+		=> value is bool b && !b;
+}

--- a/UnoCheck.Gui/MainPage.xaml
+++ b/UnoCheck.Gui/MainPage.xaml
@@ -1,0 +1,128 @@
+<Page
+	x:Class="UnoCheck.Gui.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:vm="using:UnoCheck.Gui.ViewModels"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Padding="24" RowSpacing="12">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel Grid.Row="0" Spacing="4">
+			<TextBlock Text="uno-check Doctor" Style="{StaticResource TitleTextBlockStyle}" />
+			<TextBlock Text="POC — drives the uno-check CLI through its JSONL contract (--json / --json-file / --only)"
+					   Style="{StaticResource CaptionTextBlockStyle}"
+					   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+			<TextBlock Text="{x:Bind ViewModel.EngineInfo}"
+					   Style="{StaticResource CaptionTextBlockStyle}"
+					   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+		</StackPanel>
+
+		<!-- Run options: targets, channel, verbose (persisted between sessions) -->
+		<StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="16">
+			<ItemsControl ItemsSource="{x:Bind ViewModel.Targets}" VerticalAlignment="Center">
+				<ItemsControl.ItemsPanel>
+					<ItemsPanelTemplate>
+						<StackPanel Orientation="Horizontal" Spacing="12" />
+					</ItemsPanelTemplate>
+				</ItemsControl.ItemsPanel>
+				<ItemsControl.ItemTemplate>
+					<DataTemplate x:DataType="vm:TargetOption">
+						<CheckBox Content="{x:Bind Label}" IsChecked="{x:Bind IsChecked, Mode=TwoWay}"
+								  MinWidth="0" />
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
+
+			<ComboBox ItemsSource="{x:Bind ViewModel.Channels}"
+					  SelectedIndex="{x:Bind ViewModel.SelectedChannelIndex, Mode=TwoWay}"
+					  MinWidth="140" VerticalAlignment="Center" />
+
+			<CheckBox Content="Verbose" IsChecked="{x:Bind ViewModel.Verbose, Mode=TwoWay}"
+					  MinWidth="0" VerticalAlignment="Center" />
+		</StackPanel>
+
+		<!-- Per-checkup selection from `list` json (the Setup-tab flow); unchecked become skip args -->
+		<Expander Grid.Row="2" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left">
+			<Expander.Header>
+				<StackPanel Orientation="Horizontal" Spacing="10">
+					<TextBlock Text="Checkups" />
+					<TextBlock Text="{x:Bind ViewModel.CatalogInfo, Mode=OneWay}"
+							   Style="{StaticResource CaptionTextBlockStyle}"
+							   Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+							   VerticalAlignment="Center" />
+				</StackPanel>
+			</Expander.Header>
+			<ScrollViewer MaxHeight="180">
+				<ItemsControl ItemsSource="{x:Bind ViewModel.Checkups}">
+					<ItemsControl.ItemTemplate>
+						<DataTemplate x:DataType="vm:CheckupOption">
+							<CheckBox Content="{x:Bind Title}" IsChecked="{x:Bind IsChecked, Mode=TwoWay}"
+									  MinWidth="0" Margin="0,-4" />
+						</DataTemplate>
+					</ItemsControl.ItemTemplate>
+				</ItemsControl>
+			</ScrollViewer>
+		</Expander>
+
+		<StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="12">
+			<Button Content="Run checks" Style="{StaticResource AccentButtonStyle}"
+					Command="{x:Bind ViewModel.RunCommand}" />
+			<Button Content="Cancel" Command="{x:Bind ViewModel.CancelCommand}" />
+			<TextBlock Text="{x:Bind ViewModel.Summary, Mode=OneWay}" VerticalAlignment="Center" />
+		</StackPanel>
+
+		<ScrollViewer Grid.Row="4">
+			<ItemsControl ItemsSource="{x:Bind ViewModel.Cards}">
+				<ItemsControl.ItemTemplate>
+					<DataTemplate x:DataType="vm:CheckCardViewModel">
+						<Border Margin="0,4" Padding="14,10"
+								Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+								BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+								BorderThickness="1" CornerRadius="6">
+							<Grid ColumnSpacing="12">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="28" />
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+
+								<TextBlock Grid.Column="0" Text="{x:Bind StatusGlyph, Mode=OneWay}"
+										   Foreground="{x:Bind StatusBrush, Mode=OneWay}"
+										   FontSize="18" FontWeight="Bold"
+										   VerticalAlignment="Center" HorizontalAlignment="Center" />
+
+								<StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+									<TextBlock Text="{x:Bind Name, Mode=OneWay}" FontWeight="SemiBold" />
+									<TextBlock Text="{x:Bind Message, Mode=OneWay}"
+											   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+											   TextWrapping="Wrap"
+											   Visibility="{x:Bind Message, Mode=OneWay, Converter={StaticResource NullToCollapsed}}" />
+									<TextBlock Text="{x:Bind Detail, Mode=OneWay}"
+											   Style="{StaticResource CaptionTextBlockStyle}"
+											   Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+											   TextWrapping="Wrap"
+											   Visibility="{x:Bind Detail, Mode=OneWay, Converter={StaticResource NullToCollapsed}}" />
+								</StackPanel>
+
+								<StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+									<ProgressRing IsActive="{x:Bind IsBusy, Mode=OneWay}" Width="20" Height="20" />
+									<Button Content="Fix"
+											Command="{x:Bind FixCommand}"
+											Visibility="{x:Bind CanFix, Mode=OneWay}"
+											IsEnabled="{x:Bind IsBusy, Mode=OneWay, Converter={StaticResource BoolNegation}}" />
+								</StackPanel>
+							</Grid>
+						</Border>
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/UnoCheck.Gui/MainPage.xaml.cs
+++ b/UnoCheck.Gui/MainPage.xaml.cs
@@ -1,0 +1,22 @@
+using Microsoft.UI.Xaml.Controls;
+using UnoCheck.Gui.ViewModels;
+
+namespace UnoCheck.Gui;
+
+public sealed partial class MainPage : Page
+{
+	public DoctorViewModel ViewModel { get; }
+
+	public MainPage()
+	{
+		ViewModel = new DoctorViewModel(Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread());
+		this.InitializeComponent();
+
+		// Doctor panels diagnose on open; no reason to make the user click first.
+		Loaded += (_, _) =>
+		{
+			ViewModel.XamlRoot = XamlRoot;
+			ViewModel.RunCommand.Execute(null);
+		};
+	}
+}

--- a/UnoCheck.Gui/Platforms/Desktop/Program.cs
+++ b/UnoCheck.Gui/Platforms/Desktop/Program.cs
@@ -1,0 +1,20 @@
+using Uno.UI.Hosting;
+
+namespace UnoCheck.Gui;
+
+public class Program
+{
+	[STAThread]
+	public static void Main(string[] args)
+	{
+		var host = UnoPlatformHostBuilder.Create()
+			.App(() => new App())
+			.UseX11()
+			.UseLinuxFrameBuffer()
+			.UseMacOS()
+			.UseWin32()
+			.Build();
+
+		host.Run();
+	}
+}

--- a/UnoCheck.Gui/Services/UnoCheckClient.cs
+++ b/UnoCheck.Gui/Services/UnoCheckClient.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace UnoCheck.Gui.Services;
+
+/// <summary>
+/// Drives the uno-check CLI through its structured-output contract:
+/// JSONL events on stdout for unelevated runs, and a tailed --json-file
+/// for elevated fix runs (an elevated child's stdout cannot be redirected
+/// across the elevation boundary on Windows).
+/// </summary>
+public sealed class UnoCheckClient
+{
+	/// <summary>
+	/// Version used on the dnx path. dnx runs the shipped tool package through the dotnet
+	/// host, where the exe's requireAdministrator manifest does not apply — verified: the
+	/// released tool starts unelevated this way on Windows. Bump to the first release that
+	/// contains the --json contract; until then the locally built CLI is preferred.
+	/// </summary>
+	const string PinnedToolVersion = "1.34.1";
+
+	readonly string? _localCliDll = TryFindLocalCli();
+
+	/// <summary>Human-readable description of the engine this client resolved to.</summary>
+	public string EngineDescription => _localCliDll is not null
+		? "locally built UnoCheck.dll"
+		: $"dnx uno.check@{PinnedToolVersion}";
+
+	/// <summary>Prefers the locally built UnoCheck.dll (repo checkout, has the --json contract).</summary>
+	static string? TryFindLocalCli()
+	{
+		var dir = new DirectoryInfo(AppContext.BaseDirectory);
+		while (dir is not null)
+		{
+			var candidate = Path.Combine(dir.FullName, "UnoCheck", "bin", "Debug", "net6.0", "UnoCheck.dll");
+			if (File.Exists(candidate))
+				return candidate;
+			dir = dir.Parent;
+		}
+		return null;
+	}
+
+	// dnx ships as dnx.ps1 forwarding to `dotnet dnx`, so invoke the muxer directly.
+	// --yes auto-confirms the one-time package download (cached afterwards).
+	(string fileName, string argPrefix) GetInvocation()
+		=> _localCliDll is not null
+			? ("dotnet", $"\"{_localCliDll}\" ")
+			: ("dotnet", $"dnx uno.check@{PinnedToolVersion} --yes -- ");
+
+	/// <summary>
+	/// Fetches the checkup catalog (`list --json`): the checkups applicable to this machine,
+	/// for building the selection UI. Returns an empty list if the engine predates the flag.
+	/// </summary>
+	public async Task<IReadOnlyList<(string Id, string Title)>> GetCatalogAsync(CancellationToken ct = default)
+	{
+		var items = new List<(string, string)>();
+
+		await RunAsync("list", evt =>
+		{
+			if (evt.TryGetProperty("type", out var t) && t.GetString() == "checkup_catalog"
+				&& evt.TryGetProperty("checkups", out var checkups))
+			{
+				foreach (var c in checkups.EnumerateArray())
+				{
+					var id = c.TryGetProperty("id", out var i) ? i.GetString() : null;
+					var title = c.TryGetProperty("title", out var ti) ? ti.GetString() : id;
+					if (!string.IsNullOrEmpty(id))
+						items.Add((id!, title ?? id!));
+				}
+			}
+		}, ct);
+
+		return items;
+	}
+
+	/// <summary>Unelevated run streaming JSONL from stdout. Used for diagnosis (and fixes when already admin).</summary>
+	public async Task<int> RunAsync(string args, Action<JsonElement> onEvent, CancellationToken ct = default)
+	{
+		var (fileName, argPrefix) = GetInvocation();
+
+		var psi = new ProcessStartInfo
+		{
+			FileName = fileName,
+			Arguments = $"{argPrefix}{args} --non-interactive --json",
+			UseShellExecute = false,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			CreateNoWindow = true,
+		};
+
+		using var process = new Process { StartInfo = psi };
+
+		process.OutputDataReceived += (_, e) =>
+		{
+			if (string.IsNullOrWhiteSpace(e.Data))
+				return;
+			try
+			{
+				using var doc = JsonDocument.Parse(e.Data);
+				onEvent(doc.RootElement.Clone());
+			}
+			catch (JsonException)
+			{
+				// Not an event line; ignore.
+			}
+		};
+		process.ErrorDataReceived += (_, _) => { };
+
+		process.Start();
+		process.BeginOutputReadLine();
+		process.BeginErrorReadLine();
+
+		try
+		{
+			await process.WaitForExitAsync(ct);
+		}
+		catch (OperationCanceledException)
+		{
+			try { process.Kill(entireProcessTree: true); } catch { }
+			throw;
+		}
+
+		return process.ExitCode;
+	}
+
+	/// <summary>
+	/// Elevated fix run: launches the CLI via the shell "runas" verb (UAC prompt) with
+	/// --json-file, and tails that file for events until the child exits.
+	/// </summary>
+	public async Task<int> RunFixElevatedAsync(string checkupId, string extraArgs, Action<JsonElement> onEvent, CancellationToken ct = default)
+	{
+		var (fileName, argPrefix) = GetInvocation();
+		var eventsFile = Path.Combine(Path.GetTempPath(), $"unocheck-fix-{Guid.NewGuid():n}.jsonl");
+
+		var args = $"{argPrefix}--fix --only {checkupId} {extraArgs}".Trim();
+		var psi = new ProcessStartInfo
+		{
+			FileName = fileName,
+			Arguments = $"{args} --non-interactive --json-file \"{eventsFile}\"",
+			UseShellExecute = true,
+			Verb = "runas",
+			WindowStyle = ProcessWindowStyle.Hidden,
+		};
+
+		using var process = Process.Start(psi)
+			?? throw new InvalidOperationException("Failed to start elevated uno-check.");
+
+		long offset = 0;
+		while (!process.HasExited)
+		{
+			offset = DrainEvents(eventsFile, offset, onEvent);
+			await Task.Delay(300, ct);
+		}
+		DrainEvents(eventsFile, offset, onEvent);
+
+		try { File.Delete(eventsFile); } catch { }
+
+		return process.ExitCode;
+	}
+
+	static long DrainEvents(string path, long offset, Action<JsonElement> onEvent)
+	{
+		if (!File.Exists(path))
+			return offset;
+
+		using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+		if (stream.Length <= offset)
+			return offset;
+
+		stream.Seek(offset, SeekOrigin.Begin);
+		using var reader = new StreamReader(stream);
+
+		string? line;
+		while ((line = reader.ReadLine()) is not null)
+		{
+			if (string.IsNullOrWhiteSpace(line))
+				continue;
+			try
+			{
+				using var doc = JsonDocument.Parse(line);
+				onEvent(doc.RootElement.Clone());
+			}
+			catch (JsonException)
+			{
+				// Partial trailing line; re-read from here next drain.
+				return stream.Position - System.Text.Encoding.UTF8.GetByteCount(line + Environment.NewLine);
+			}
+		}
+
+		return stream.Position;
+	}
+
+	public static bool IsElevated()
+	{
+		if (!OperatingSystem.IsWindows())
+			return false;
+		using var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+		return new System.Security.Principal.WindowsPrincipal(identity)
+			.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+	}
+}

--- a/UnoCheck.Gui/UnoCheck.Gui.csproj
+++ b/UnoCheck.Gui/UnoCheck.Gui.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Uno.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net10.0-desktop</TargetFrameworks>
+		<OutputType>Exe</OutputType>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<UnoSingleProject>true</UnoSingleProject>
+		<RootNamespace>UnoCheck.Gui</RootNamespace>
+
+		<ApplicationTitle>uno-check Doctor (POC)</ApplicationTitle>
+		<ApplicationId>uno.platform.check.gui.poc</ApplicationId>
+
+		<UnoFeatures>
+			SkiaRenderer;
+		</UnoFeatures>
+
+		<!-- POC: not part of UnoCheck.sln / CI. Build from this directory so the
+		     local global.json (SDK 10) applies instead of the repo root's. -->
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
+	</ItemGroup>
+
+</Project>

--- a/UnoCheck.Gui/ViewModels/DoctorViewModel.cs
+++ b/UnoCheck.Gui/ViewModels/DoctorViewModel.cs
@@ -1,0 +1,494 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using UnoCheck.Gui.Services;
+
+namespace UnoCheck.Gui.ViewModels;
+
+public partial class DoctorViewModel : ObservableObject
+{
+	readonly UnoCheckClient _client = new();
+	readonly DispatcherQueue _dispatcher;
+	CancellationTokenSource? _cts;
+
+	public DoctorViewModel(DispatcherQueue dispatcher)
+	{
+		_dispatcher = dispatcher;
+
+		Targets = new ObservableCollection<TargetOption>(BuildDefaultTargets());
+		LoadSettings();
+	}
+
+	public ObservableCollection<CheckCardViewModel> Cards { get; } = new();
+
+	// ── Run options (mirrors the Mountaineer Doctor screen) ──────────
+
+	/// <summary>Per-checkup selection, populated from `list --json` (the Setup-tab flow).</summary>
+	public ObservableCollection<CheckupOption> Checkups { get; } = new();
+
+	[ObservableProperty]
+	private string _catalogInfo = "";
+
+	HashSet<string> _persistedUncheckedCheckups = new(StringComparer.OrdinalIgnoreCase);
+
+	async Task EnsureCatalogAsync()
+	{
+		if (Checkups.Count > 0)
+			return;
+
+		var sw = System.Diagnostics.Stopwatch.StartNew();
+		var catalog = await Task.Run(() => _client.GetCatalogAsync());
+		sw.Stop();
+
+		_dispatcher.TryEnqueue(() =>
+		{
+			foreach (var (id, title) in catalog)
+				Checkups.Add(new CheckupOption(id, title, isChecked: !_persistedUncheckedCheckups.Contains(id)));
+
+			CatalogInfo = catalog.Count > 0
+				? $"catalog: {catalog.Count} checkups ({sw.ElapsedMilliseconds} ms)"
+				: "catalog: unavailable (engine predates list --json)";
+		});
+	}
+
+	public ObservableCollection<TargetOption> Targets { get; }
+
+	public string[] Channels { get; } = ["Stable", "Preview", "Preview major", "Main"];
+
+	[ObservableProperty]
+	private int _selectedChannelIndex;
+
+	[ObservableProperty]
+	private bool _verbose;
+
+	static IEnumerable<TargetOption> BuildDefaultTargets()
+	{
+		// Defaults suit the current OS: no Apple-only targets preselected on Windows, etc.
+		var isWindows = OperatingSystem.IsWindows();
+		var isMac = OperatingSystem.IsMacOS();
+
+		yield return new TargetOption("WASM", "wasm", true);
+		yield return new TargetOption("Android", "android", true);
+		yield return new TargetOption("iOS", "ios", isMac);
+		yield return new TargetOption("Skia/Desktop", "skia", true);
+		yield return new TargetOption("Windows", "windows", isWindows);
+		yield return new TargetOption("macOS", "macos", isMac);
+	}
+
+	string BuildRunArgs()
+	{
+		var args = string.Join(" ", Targets.Where(t => t.IsChecked).Select(t => $"--target {t.Flag}"));
+
+		// Unchecked checkups become --skip: the run covers everything selected, and
+		// skipped ones still resolve in the stream (as "skipped"), so the UI stays honest.
+		args += string.Concat(Checkups.Where(c => !c.IsChecked).Select(c => $" --skip {c.Id}"));
+
+		args += SelectedChannelIndex switch
+		{
+			1 => " --pre",
+			2 => " --pre-major",
+			3 => " --main",
+			_ => "",
+		};
+
+		if (Verbose)
+			args += " -v";
+
+		return args.Trim();
+	}
+
+	// ── Settings persistence (spec 084: no re-picking every visit) ───
+
+	static string SettingsPath => Path.Combine(
+		Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+		"UnoCheck.Gui", "settings.json");
+
+	void LoadSettings()
+	{
+		try
+		{
+			if (!File.Exists(SettingsPath))
+				return;
+
+			var root = JsonDocument.Parse(File.ReadAllText(SettingsPath)).RootElement;
+
+			if (root.TryGetProperty("targets", out var targets))
+			{
+				var picked = targets.EnumerateArray().Select(t => t.GetString()).ToHashSet();
+				foreach (var t in Targets)
+					t.IsChecked = picked.Contains(t.Flag);
+			}
+			if (root.TryGetProperty("channel", out var ch))
+				SelectedChannelIndex = Math.Clamp(ch.GetInt32(), 0, Channels.Length - 1);
+			if (root.TryGetProperty("verbose", out var v))
+				Verbose = v.GetBoolean();
+			if (root.TryGetProperty("uncheckedCheckups", out var unchecked_))
+				_persistedUncheckedCheckups = unchecked_.EnumerateArray()
+					.Select(u => u.GetString())
+					.Where(u => !string.IsNullOrEmpty(u))
+					.ToHashSet(StringComparer.OrdinalIgnoreCase)!;
+		}
+		catch
+		{
+			// Corrupt/unreadable settings: fall back to defaults.
+		}
+	}
+
+	void SaveSettings()
+	{
+		try
+		{
+			Directory.CreateDirectory(Path.GetDirectoryName(SettingsPath)!);
+			File.WriteAllText(SettingsPath, JsonSerializer.Serialize(new
+			{
+				targets = Targets.Where(t => t.IsChecked).Select(t => t.Flag),
+				channel = SelectedChannelIndex,
+				verbose = Verbose,
+				uncheckedCheckups = Checkups.Where(c => !c.IsChecked).Select(c => c.Id),
+			}));
+		}
+		catch
+		{
+			// Persistence is a convenience; never fail a run over it.
+		}
+	}
+
+	[ObservableProperty]
+	[NotifyCanExecuteChangedFor(nameof(RunCommand))]
+	[NotifyCanExecuteChangedFor(nameof(CancelCommand))]
+	private bool _isRunning;
+
+	[ObservableProperty]
+	private string _summary = "Ready — run a check to diagnose this machine.";
+
+	/// <summary>Which uno-check engine the client resolved (local build vs dnx-pinned package).</summary>
+	public string EngineInfo => $"engine: {_client.EngineDescription}";
+
+	[RelayCommand(CanExecute = nameof(CanRun))]
+	private async Task RunAsync()
+	{
+		IsRunning = true;
+		Cards.Clear();
+		Summary = "Running uno-check…";
+		_cts = new CancellationTokenSource();
+
+		try
+		{
+			await EnsureCatalogAsync();
+			SaveSettings();
+
+			// Timing matters here: this measures the real end-to-end diagnosis cost the
+			// Studio environment panel would pay per background run.
+			var sw = System.Diagnostics.Stopwatch.StartNew();
+			var exit = await Task.Run(() => _client.RunAsync(BuildRunArgs(), OnEvent, _cts.Token));
+			sw.Stop();
+
+			_lastRunDuration = sw.Elapsed;
+			Summary = Summary.StartsWith("Running")
+				? $"Run finished (exit {exit}) in {sw.Elapsed.TotalSeconds:0.0}s."
+				: $"{Summary} ({sw.Elapsed.TotalSeconds:0.0}s)";
+		}
+		catch (OperationCanceledException)
+		{
+			Summary = "Canceled.";
+		}
+		catch (Exception ex)
+		{
+			Summary = $"Failed to run uno-check: {ex.Message}";
+		}
+		finally
+		{
+			IsRunning = false;
+			_cts = null;
+		}
+	}
+
+	TimeSpan _lastRunDuration;
+
+	private bool CanRun() => !IsRunning;
+
+	[RelayCommand(CanExecute = nameof(IsRunning))]
+	private void Cancel() => _cts?.Cancel();
+
+	/// <summary>Set by the view; ContentDialogs need a live XamlRoot.</summary>
+	public XamlRoot? XamlRoot { get; set; }
+
+	public async Task FixAsync(CheckCardViewModel card)
+	{
+		card.IsBusy = true;
+
+		// Progress popup: fix events stream into it live (tailed from --json-file when
+		// the child runs elevated — its stdout can't cross the UAC boundary).
+		var log = new TextBlock { TextWrapping = TextWrapping.Wrap, FontSize = 12, Text = "Starting fix…" };
+		var progress = new ProgressBar { IsIndeterminate = true };
+		var dialog = new ContentDialog
+		{
+			Title = $"Fixing: {card.Name}",
+			Content = new StackPanel
+			{
+				Spacing = 8,
+				MinWidth = 420,
+				Children = { progress, new ScrollViewer { Content = log, MaxHeight = 320 } },
+			},
+			PrimaryButtonText = "Close",
+			IsPrimaryButtonEnabled = false,
+			XamlRoot = XamlRoot,
+		};
+
+		void AppendLine(string line)
+			=> _dispatcher.TryEnqueue(() => log.Text += Environment.NewLine + line);
+
+		var fixSucceeded = false;
+
+		void OnFixEvent(JsonElement evt)
+		{
+			OnEvent(evt);
+
+			var type = evt.TryGetProperty("type", out var t) ? t.GetString() : null;
+			switch (type)
+			{
+				case "fix_started":
+					AppendLine($"Applying {evt.GetProperty("solution").GetString()}…");
+					break;
+				case "fix_progress" or "checkup_progress":
+					if (evt.TryGetProperty("message", out var m) && m.GetString() is { Length: > 0 } msg)
+						AppendLine(msg);
+					break;
+				case "fix_result":
+					fixSucceeded = evt.GetProperty("success").GetBoolean();
+					AppendLine(fixSucceeded
+						? "Fix applied — verifying…"
+						: evt.TryGetProperty("error", out var err) ? $"Fix failed: {err.GetString()}" : "Fix failed.");
+					break;
+			}
+		}
+
+		var showTask = dialog.ShowAsync();
+		var failed = false;
+
+		try
+		{
+			// Fixes may write to machine-scoped locations; elevate the child on Windows
+			// unless this process is already admin. No separate re-check needed:
+			// uno-check re-examines the checkup itself after a successful fix, and that
+			// checkup_result flows through the same event stream to update the card.
+			// The fix must run against the same manifest channel as the diagnosis.
+			var channelArg = SelectedChannelIndex switch { 1 => "--pre", 2 => "--pre-major", 3 => "--main", _ => "" };
+
+			var elevated = OperatingSystem.IsWindows() && !UnoCheckClient.IsElevated();
+			_ = elevated
+				? await Task.Run(() => _client.RunFixElevatedAsync(card.Id, channelArg, OnFixEvent))
+				: await Task.Run(() => _client.RunAsync($"--fix --only {card.Id} {channelArg}".Trim(), OnFixEvent));
+
+			failed = !fixSucceeded;
+		}
+		catch (Exception ex)
+		{
+			// Includes the user declining the UAC prompt (Win32 error 1223).
+			failed = true;
+			AppendLine($"Fix did not run: {ex.Message}");
+		}
+		finally
+		{
+			card.IsBusy = false;
+
+			var close = !failed;
+			_dispatcher.TryEnqueue(async () =>
+			{
+				progress.IsIndeterminate = false;
+				progress.Value = 100;
+
+				if (close)
+				{
+					// Success: let the final state register, then get out of the way.
+					await Task.Delay(600);
+					dialog.Hide();
+				}
+				else
+				{
+					// Failure: keep the log on screen until the user closes it.
+					dialog.IsPrimaryButtonEnabled = true;
+				}
+			});
+		}
+
+		await showTask;
+	}
+
+	void OnEvent(JsonElement evt)
+	{
+		var type = evt.TryGetProperty("type", out var t) ? t.GetString() : null;
+		if (type is null)
+			return;
+
+		_dispatcher.TryEnqueue(() => Apply(type, evt));
+	}
+
+	void Apply(string type, JsonElement evt)
+	{
+		switch (type)
+		{
+			case "checkup_started":
+			{
+				var id = evt.GetProperty("id").GetString() ?? "";
+				var card = FindOrAddCard(id);
+				card.Name = evt.TryGetProperty("name", out var n) ? n.GetString() ?? id : id;
+				card.SetStatus("running");
+				break;
+			}
+			case "checkup_progress":
+			{
+				if (evt.TryGetProperty("id", out var idProp) && idProp.GetString() is { } id
+					&& evt.TryGetProperty("message", out var m))
+				{
+					FindOrAddCard(id).Detail = m.GetString();
+				}
+				break;
+			}
+			case "checkup_result":
+			{
+				var check = evt.GetProperty("check");
+				var id = check.GetProperty("id").GetString() ?? "";
+				var card = FindOrAddCard(id);
+				card.Name = check.TryGetProperty("name", out var n) ? n.GetString() ?? id : id;
+				card.Message = check.TryGetProperty("message", out var msg) ? msg.GetString() : null;
+				if (check.TryGetProperty("skip_reason", out var skip))
+					card.Message = skip.GetString();
+				card.CanFix = check.TryGetProperty("fix", out var fix)
+					&& fix.TryGetProperty("auto_fixable", out var af) && af.GetBoolean();
+				card.Detail = null; // final state: drop stale progress text
+				card.SetStatus(check.GetProperty("status").GetString() ?? "error");
+				break;
+			}
+			case "fix_progress":
+			{
+				if (evt.TryGetProperty("id", out var idProp) && idProp.GetString() is { } id
+					&& evt.TryGetProperty("message", out var m))
+				{
+					FindOrAddCard(id).Detail = m.GetString();
+				}
+				break;
+			}
+			case "fix_result":
+			{
+				var id = evt.GetProperty("id").GetString() ?? "";
+				var card = FindOrAddCard(id);
+				var success = evt.GetProperty("success").GetBoolean();
+				card.Detail = success
+					? "Fix applied — re-checking…"
+					: (evt.TryGetProperty("error", out var err) ? $"Fix failed: {err.GetString()}" : "Fix failed.");
+				break;
+			}
+			case "report":
+			{
+				var summary = evt.GetProperty("report").GetProperty("summary");
+				Summary = $"Done — {summary.GetProperty("ok").GetInt32()} ok, " +
+					$"{summary.GetProperty("warning").GetInt32()} warnings, " +
+					$"{summary.GetProperty("error").GetInt32()} errors, " +
+					$"{summary.GetProperty("skipped").GetInt32()} skipped.";
+				break;
+			}
+		}
+	}
+
+	CheckCardViewModel FindOrAddCard(string id)
+	{
+		var card = Cards.FirstOrDefault(c => c.Id == id);
+		if (card is null)
+		{
+			card = new CheckCardViewModel(this) { Id = id, Name = id };
+			Cards.Add(card);
+		}
+		return card;
+	}
+}
+
+public partial class CheckupOption : ObservableObject
+{
+	public CheckupOption(string id, string title, bool isChecked)
+	{
+		Id = id;
+		Title = title;
+		_isChecked = isChecked;
+	}
+
+	public string Id { get; }
+	public string Title { get; }
+
+	[ObservableProperty]
+	private bool _isChecked;
+}
+
+public partial class TargetOption : ObservableObject
+{
+	public TargetOption(string label, string flag, bool isChecked)
+	{
+		Label = label;
+		Flag = flag;
+		_isChecked = isChecked;
+	}
+
+	public string Label { get; }
+	public string Flag { get; }
+
+	[ObservableProperty]
+	private bool _isChecked;
+}
+
+public partial class CheckCardViewModel : ObservableObject
+{
+	readonly DoctorViewModel _owner;
+
+	public CheckCardViewModel(DoctorViewModel owner)
+	{
+		_owner = owner;
+	}
+
+	public string Id { get; init; } = "";
+
+	[ObservableProperty]
+	private string _name = "";
+
+	[ObservableProperty]
+	private string? _message;
+
+	[ObservableProperty]
+	private string? _detail;
+
+	[ObservableProperty]
+	private bool _canFix;
+
+	[ObservableProperty]
+	private bool _isBusy;
+
+	[ObservableProperty]
+	private string _statusGlyph = "○";
+
+	[ObservableProperty]
+	private Brush _statusBrush = new SolidColorBrush(Colors.Gray);
+
+	public void SetStatus(string status)
+	{
+		(StatusGlyph, StatusBrush) = status switch
+		{
+			"ok" => ("✔", (Brush)new SolidColorBrush(Colors.Green)),
+			"warning" => ("!", new SolidColorBrush(Colors.DarkOrange)),
+			"error" => ("✘", new SolidColorBrush(Colors.Red)),
+			"skipped" => ("↷", new SolidColorBrush(Colors.Gray)),
+			"running" => ("…", new SolidColorBrush(Colors.DodgerBlue)),
+			_ => ("○", new SolidColorBrush(Colors.Gray)),
+		};
+
+		if (status is "ok" or "skipped")
+			CanFix = false;
+	}
+
+	[RelayCommand]
+	private Task FixAsync() => _owner.FixAsync(this);
+}

--- a/UnoCheck.Gui/global.json
+++ b/UnoCheck.Gui/global.json
@@ -1,0 +1,10 @@
+{
+	"msbuild-sdks": {
+		"Uno.Sdk": "6.5.31"
+	},
+	"sdk": {
+		"version": "10.0.100",
+		"rollForward": "latestFeature",
+		"allowPrerelease": true
+	}
+}


### PR DESCRIPTION
## SummaryStacked on #551 (merge that first — this PR should only show `UnoCheck.Gui/`).Proof-of-concept Uno Platform desktop app proving the JSONL contract end-to-end before host integration:- Auto-runs diagnosis on launch; per-check cards resolve live from the JSONL stream (ok / warning / error / skipped — including the not-applicable skips the contract now guarantees)- Per-card **Fix**: elevated child (`--fix --only <id> --json-file <fresh-path>`), progress streamed into a popup tailed from the file, auto-closes on success, stays open with the log on failure; the fix child''s own re-examined result updates the card- Run options: target checkboxes (OS-aware defaults), Stable/Preview/Preview-major/Main channel (also applied to fix runs), verbose — persisted across sessions- Excluded from UnoCheck.sln/CI; built from its own directory (local net10 `global.json`); prefers a locally built `UnoCheck.dll` (has the `--json` contract), otherwise runs the shipped tool via `dotnet dnx uno.check@<pinned> --yes` — verified on Windows that the dnx path executes through the dotnet host where the exe's `requireAdministrator` manifest does not apply, so unelevated background diagnosis works with the unmodified shipped package (resolved engine shown in the header; pinned version bumps once a release contains the contract)Verified against the final #551 contract: live cards under verbose mode (previously impossible — stdout was polluted), persisted options reload, not-applicable checkups render as skipped, and Fix buttons appear exactly where `fix.auto_fixable` is true.Not yet adopted from the final contract (deliberately, pending review of #551): passing `--correlation-id` to fix children, and consuming `fix.args` verbatim instead of building the argument list locally. Both are small follow-ups here once the contract merges.Open question for review: does the POC live here long-term, or move once host integration starts?🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Known gap (from #553 review):** the PoC does not pass `--allow-elevation-prompt` when launching fix children, so on macOS/Linux protected fixes fail until it adopts the #553/#554 engine; its `IsElevated()` returning false on non-Windows is the correct behavior for that flag. Small follow-up here once the elevation PRs merge.
