### PR TITLE
feat: add macOS authorization for structured fixes

### DIFF
--- a/UnoCheck.Tests/DotNetSdkScriptInstallSolutionTests.cs
+++ b/UnoCheck.Tests/DotNetSdkScriptInstallSolutionTests.cs
@@ -1,0 +1,29 @@
+using DotNetCheck.Solutions;
+
+namespace UnoCheck.Tests;
+
+public class DotNetSdkScriptInstallSolutionTests
+{
+    [Fact]
+    public void IsDirectoryWritableOrCreatable_UsesNearestExistingParent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "uno-check-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var nestedPath = Path.Combine(tempDir, "not-created", "dotnet");
+
+            Assert.True(DotNetSdkScriptInstallSolution.IsDirectoryWritableOrCreatable(nestedPath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsDirectoryWritableOrCreatable_MissingPath_ReturnsFalse()
+    {
+        Assert.False(DotNetSdkScriptInstallSolution.IsDirectoryWritableOrCreatable(string.Empty));
+    }
+}

--- a/UnoCheck.Tests/DotNetWorkloadFeedbackTests.cs
+++ b/UnoCheck.Tests/DotNetWorkloadFeedbackTests.cs
@@ -57,6 +57,21 @@ public class DotNetWorkloadFeedbackTests
     }
 
     [Fact]
+    public void BuildInstallArgs_PreservesPathsAndSourcesAsSeparateArguments()
+    {
+        var args = DotNetWorkloadManager.BuildInstallArgs(
+            sdkVersion: "10.0.103",
+            rollbackFile: "/Users/Test User/workload.json",
+            workloadIds: ["wasm-tools"],
+            packageSources: ["/Users/Test User/local feed"],
+            verbose: false);
+
+        Assert.Equal(
+            ["workload", "install", "--from-rollback-file", "/Users/Test User/workload.json", "wasm-tools", "--source", "/Users/Test User/local feed"],
+            args);
+    }
+
+    [Fact]
     public void BuildRepairArgs_AddsDetailedVerbosityWhenVerboseEnabled()
     {
         var args = DotNetWorkloadManager.BuildRepairArgs(

--- a/UnoCheck.Tests/JsonStructuredOutputTests.cs
+++ b/UnoCheck.Tests/JsonStructuredOutputTests.cs
@@ -118,6 +118,77 @@ public class BuildHealthCheckTests
 
         Assert.Null(CheckCommand.BuildHealthCheck(checkup, diagnosis).Fix);
     }
+
+    [Fact]
+    public void Error_Without_Message_Falls_Back_To_Suggestion_Description()
+    {
+        // Some checkups (e.g. a workloads mismatch) report status without a message;
+        // hosts would render a bare card with no explanation.
+        var checkup = new FakeCheckup("dotnetworkloads-10.0.201");
+        var diagnosis = new DiagnosticResult(
+            Status.Error, checkup,
+            new Suggestion("Install .NET workloads", "Installing .NET workloads.", new NoopSolution()));
+
+        var check = CheckCommand.BuildHealthCheck(checkup, diagnosis);
+
+        Assert.Equal("Installing .NET workloads.", check.Message);
+    }
+
+    [Fact]
+    public void Error_Without_Message_Or_Description_Falls_Back_To_Suggestion_Name()
+    {
+        var checkup = new FakeCheckup("unosdk");
+        var diagnosis = new DiagnosticResult(Status.Error, checkup, new Suggestion("Install the SDK", new NoopSolution()));
+
+        var check = CheckCommand.BuildHealthCheck(checkup, diagnosis);
+
+        Assert.Equal("Install the SDK", check.Message);
+    }
+
+    [Fact]
+    public void Explicit_Message_Wins_Over_Suggestion_Fallback()
+    {
+        var checkup = new FakeCheckup("unosdk");
+        var diagnosis = new DiagnosticResult(
+            Status.Error, checkup, "Uno.Sdk 6.7.22 is not installed.",
+            new Suggestion("Install the SDK", new NoopSolution()));
+
+        var check = CheckCommand.BuildHealthCheck(checkup, diagnosis);
+
+        Assert.Equal("Uno.Sdk 6.7.22 is not installed.", check.Message);
+    }
+}
+
+public class IsCallerNamedForFixTests
+{
+    [Fact]
+    public void Without_Only_Every_Checkup_Qualifies()
+    {
+        Assert.True(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", null));
+        Assert.True(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", []));
+    }
+
+    [Fact]
+    public void Caller_Named_Id_Qualifies_Case_Insensitively()
+    {
+        Assert.True(CheckCommand.IsCallerNamedForFix("unosdk", ["UnoSdk"]));
+    }
+
+    [Fact]
+    public void Dependency_Included_Checkup_Is_Not_AutoFixed()
+    {
+        // --only unosdk pulls dotnet/workloads in as examine-only dependencies; fixing
+        // them would raise an elevation prompt for a command the user never requested.
+        Assert.False(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", ["unosdk"]));
+        Assert.False(CheckCommand.IsCallerNamedForFix("dotnet", ["unosdk"]));
+    }
+
+    [Fact]
+    public void Prefix_Does_Not_Qualify_A_Caller_Name()
+    {
+        // Caller ids match exactly — the one-way prefix rule is for dependency ids only.
+        Assert.False(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", ["dotnetworkloads"]));
+    }
 }
 
 public class SafeCheckupIdTests

--- a/UnoCheck.Tests/LinuxAdministratorCommandRunnerTests.cs
+++ b/UnoCheck.Tests/LinuxAdministratorCommandRunnerTests.cs
@@ -1,0 +1,75 @@
+using DotNetCheck;
+
+namespace UnoCheck.Tests;
+
+public class LinuxAdministratorCommandRunnerTests
+{
+    [Fact]
+    public void BuildArguments_PreservesArgumentBoundariesVerbatim()
+    {
+        var arguments = LinuxAdministratorCommandRunner.BuildArguments(
+            "/home/test user/.dotnet/dotnet",
+            ["workload", "install", "value with spaces", "$(touch /tmp/bad)", "it's-safe"]);
+
+        Assert.Equal(
+            ["/home/test user/.dotnet/dotnet", "workload", "install", "value with spaces", "$(touch /tmp/bad)", "it's-safe"],
+            arguments);
+    }
+
+    [Fact]
+    public void BuildArguments_RequiresAnExecutable()
+    {
+        Assert.Throws<ArgumentException>(() => LinuxAdministratorCommandRunner.BuildArguments(" ", []));
+    }
+
+    [Theory]
+    [InlineData(true, false, true, true, true)]
+    [InlineData(true, false, true, false, false)]
+    [InlineData(true, true, true, true, false)]
+    [InlineData(true, false, false, true, false)]
+    [InlineData(false, false, true, true, false)]
+    public void ShouldUseLinuxAdministratorPrompt_RequiresLinuxStructuredHostOutsideCi(
+        bool isLinux,
+        bool ci,
+        bool structuredOutput,
+        bool allowElevationPrompt,
+        bool expected)
+    {
+        Assert.Equal(expected, Util.ShouldUseLinuxAdministratorPrompt(isLinux, ci, structuredOutput, allowElevationPrompt));
+    }
+
+    [Fact]
+    public void WasDeclined_RecognizesDismissedExitCode()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], [], 126);
+
+        Assert.True(LinuxAdministratorCommandRunner.WasDeclined(result));
+    }
+
+    [Fact]
+    public void WasDeclined_RecognizesDismissedMessage()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult(
+            [],
+            ["Error executing command as another user: Request dismissed"],
+            127);
+
+        Assert.True(LinuxAdministratorCommandRunner.WasDeclined(result));
+    }
+
+    [Fact]
+    public void WasDeclined_DoesNotHideOtherFailures()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], ["dotnet workload install failed"], 1);
+
+        Assert.False(LinuxAdministratorCommandRunner.WasDeclined(result));
+    }
+
+    [Fact]
+    public void WasDeclined_IgnoresSuccessfulRuns()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], [], 0);
+
+        Assert.False(LinuxAdministratorCommandRunner.WasDeclined(result));
+    }
+}

--- a/UnoCheck.Tests/MacOsAdministratorCommandRunnerTests.cs
+++ b/UnoCheck.Tests/MacOsAdministratorCommandRunnerTests.cs
@@ -1,0 +1,52 @@
+using DotNetCheck;
+
+namespace UnoCheck.Tests;
+
+public class MacOsAdministratorCommandRunnerTests
+{
+    [Fact]
+    public void BuildCommandLine_QuotesExecutableAndEveryArgument()
+    {
+        var command = MacOsAdministratorCommandRunner.BuildCommandLine(
+            "/Users/Test User/.dotnet/dotnet",
+            ["workload", "install", "value with spaces", "$(touch /tmp/bad)", "it's-safe"]);
+
+        Assert.Equal(
+            "'/Users/Test User/.dotnet/dotnet' 'workload' 'install' 'value with spaces' '$(touch /tmp/bad)' 'it'\"'\"'s-safe'",
+            command);
+    }
+
+    [Theory]
+    [InlineData(true, false, true, true, true)]
+    [InlineData(true, false, true, false, false)]
+    [InlineData(true, true, true, true, false)]
+    [InlineData(true, false, false, true, false)]
+    [InlineData(false, false, true, true, false)]
+    public void ShouldUseMacOsAdministratorPrompt_RequiresMacStructuredHostOutsideCi(
+        bool isMac,
+        bool ci,
+        bool structuredOutput,
+        bool allowElevationPrompt,
+        bool expected)
+    {
+        Assert.Equal(expected, Util.ShouldUseMacOsAdministratorPrompt(isMac, ci, structuredOutput, allowElevationPrompt));
+    }
+
+    [Theory]
+    [InlineData("execution error: User canceled. (-128)")]
+    [InlineData("Execution error: User cancelled. (-128)")]
+    public void WasDeclined_RecognizesMacOsAuthorizationCancellation(string error)
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], [error], 1);
+
+        Assert.True(MacOsAdministratorCommandRunner.WasDeclined(result));
+    }
+
+    [Fact]
+    public void WasDeclined_DoesNotHideOtherFailures()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], ["xcodebuild failed"], 1);
+
+        Assert.False(MacOsAdministratorCommandRunner.WasDeclined(result));
+    }
+}

--- a/UnoCheck.Tests/ShellProcessRunnerTests.cs
+++ b/UnoCheck.Tests/ShellProcessRunnerTests.cs
@@ -6,6 +6,25 @@ namespace UnoCheck.Tests;
 public class ShellProcessRunnerTests
 {
 	[Fact]
+	public void WaitForExit_ArgumentList_PreservesArgumentBoundaries()
+	{
+		if (OperatingSystem.IsWindows())
+			return;
+
+		var sut = new ShellProcessRunner(new ShellProcessRunnerOptions("/bin/sh", string.Empty)
+		{
+			ArgumentList = ["-c", "printf '%s' \"$1\"", "sh", "value with spaces; $(echo unsafe)"],
+			UseSystemShell = false,
+			RedirectOutput = true,
+		});
+
+		var result = sut.WaitForExit();
+
+		Assert.True(result.Success);
+		Assert.Equal("value with spaces; $(echo unsafe)", string.Join(Environment.NewLine, result.StandardOutput));
+	}
+
+	[Fact]
 	public void WaitForExit_CapturesStdOutAndStdErr_AndReturnsExitCode()
 	{
 		var (executable, args) = GetShellCommand(

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -59,6 +59,7 @@ namespace DotNetCheck.Cli
 			Util.Verbose = settings.Verbose;
 			Util.LogFile = settings.LogFile;
 			Util.CI = settings.CI;
+			Util.AllowElevationPrompt = settings.AllowElevationPrompt;
 			if (settings.CI)
 				settings.NonInteractive = true;
 

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -395,8 +395,11 @@ namespace DotNetCheck.Cli
 					// needs to have a remedy available to even bother asking/trying
 					var doFix = diagnosis.Suggestion.HasSolution
 						&& (
-							// --fix + --non-interactive == auto fix, no prompt
-							(settings.NonInteractive && settings.Fix)
+							// --fix + --non-interactive == auto fix, no prompt — but only for
+							// checkups the caller named with --only: dependencies are examined
+							// for context, never auto-fixed. A host-side elevation prompt must
+							// describe the fix the user actually requested, not a dependency's.
+							(settings.NonInteractive && settings.Fix && IsCallerNamedForFix(checkup.Id, settings.Only))
 							// interactive (default) + prompt/confirm they want to fix
 							|| (!settings.NonInteractive && AnsiConsole.Confirm($"[bold]{Icon.Bell} Attempt to fix?[/]"))
 						);
@@ -639,6 +642,17 @@ namespace DotNetCheck.Cli
 		private string _activeFixCheckupId;
 
 		/// <summary>
+		/// Whether a checkup was named by the caller (exact, case-insensitive) and may be
+		/// auto-fixed in a non-interactive --fix --only run. Without --only every checkup
+		/// qualifies; with --only, dependency-included checkups are examined but not fixed.
+		/// </summary>
+#nullable enable
+		internal static bool IsCallerNamedForFix(string checkupId, string[]? only)
+			=> only is not { Length: > 0 }
+				|| only.Any(o => string.Equals(o, checkupId, StringComparison.OrdinalIgnoreCase));
+#nullable restore
+
+		/// <summary>
 		/// --only: scope the run to the requested checkup(s) plus their required dependencies.
 		/// Caller-supplied ids match exactly (case-insensitive) so a per-item fix can never
 		/// select siblings the caller did not name. Ids declared by dependencies keep the
@@ -715,12 +729,23 @@ namespace DotNetCheck.Cli
 				};
 			}
 
+			// Some checkups report a non-Ok status with no message (e.g. a workloads mismatch),
+			// which renders as a bare card in hosts. Fall back to the suggestion text so the
+			// JSON always carries a human-readable reason for a failed check.
+			var message = diagnosis.Message;
+			if (string.IsNullOrEmpty(message) && diagnosis.Status != Models.Status.Ok && diagnosis.HasSuggestion)
+			{
+				message = string.IsNullOrEmpty(diagnosis.Suggestion.Description)
+					? diagnosis.Suggestion.Name
+					: diagnosis.Suggestion.Description;
+			}
+
 			return new Json.HealthCheck
 			{
 				Id = checkup.Id,
 				Name = checkup.Title,
 				Status = Json.JsonlOutput.StatusName(diagnosis.Status),
-				Message = diagnosis.Message,
+				Message = message,
 				Fix = fix,
 			};
 		}

--- a/UnoCheck/CheckSettings.Uno.cs
+++ b/UnoCheck/CheckSettings.Uno.cs
@@ -51,5 +51,10 @@ Targets: webassembly ios android macos linux windows"
         [Description(
             @"Correlation id stamped on structured-output events. Hosts pass their own id when launching a child process (e.g. an elevated fix) so both processes report as one logical run. Defaults to a new id per run.")]
         public string? CorrelationId { get; set; }
+
+        [CommandOption("--allow-elevation-prompt")]
+        [Description(
+            @"Allow a structured macOS fix run to display the system administrator authorization dialog. Ignored in CI.")]
+        public bool AllowElevationPrompt { get; set; }
 	}
 }

--- a/UnoCheck/CheckSettings.Uno.cs
+++ b/UnoCheck/CheckSettings.Uno.cs
@@ -54,7 +54,7 @@ Targets: webassembly ios android macos linux windows"
 
         [CommandOption("--allow-elevation-prompt")]
         [Description(
-            @"Allow a structured macOS fix run to display the system administrator authorization dialog. Ignored in CI.")]
+            @"Allow a structured macOS or Linux fix run to display the system authorization dialog (macOS administrator prompt / Linux polkit). Ignored in CI.")]
         public bool AllowElevationPrompt { get; set; }
 	}
 }

--- a/UnoCheck/Checkups/XCodeCheckup.cs
+++ b/UnoCheck/Checkups/XCodeCheckup.cs
@@ -135,10 +135,16 @@ namespace DotNetCheck.Checkups
 						Status.Error,
 						this,
 						new Suggestion("Run xcode-select -s <Path>",
-							new Solutions.ActionSolution((sln, cancelToken) =>
+							new Solutions.ActionSolution(async (sln, cancelToken) =>
 							{
-								ShellProcessRunner.Run("xcode-select", "-s " + eligibleXcode.Path);
-								return Task.CompletedTask;
+								var result = await Util.WrapShellCommandWithSudo(
+									"/usr/bin/xcode-select",
+									workingDir: null,
+									verbose: Util.Verbose,
+									cancellationToken: cancelToken,
+									args: new[] { "-s", eligibleXcode.Path });
+								if (!result.Success)
+									throw new InvalidOperationException(result.GetOutput());
 							}))));
 				}
 

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -502,9 +502,9 @@ namespace DotNetCheck.DotNet
 		/// </summary>
 		async Task<ShellProcessRunner.ShellProcessResult> RetryWithSudo(string dotnetExe, CancellationToken cancellationToken, string[] args)
 		{
-			// Structured macOS hosts opt into the system authorization dialog. Do not use
-			// an unrelated Terminal sudo ticket: authorization belongs to this fix request.
-			if (Util.UseMacOsAdministratorPrompt)
+			// Structured macOS/Linux hosts opt into the system authorization dialog. Do not
+			// use an unrelated terminal sudo ticket: authorization belongs to this fix request.
+			if (Util.UseAdministratorPrompt)
 			{
 				return await Util.WrapShellCommandWithSudo(
 					"env",

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -82,19 +82,16 @@ namespace DotNetCheck.DotNet
 		/// <see cref="WorkloadCliEnv"/> re-set inside the elevated child. Required for sudo paths
 		/// because sudo's default <c>env_reset</c> strips any var we set on the parent process.
 		///
-		/// Two variants exist because the consumers tokenize the args differently and the dotnet
-		/// path has to be quoted for the right consumer. Use this one for callers that hand the
-		/// args off to <see cref="Util.WrapShellCommandWithSudoNoPrompt"/>: that helper interpolates
-		/// the args into a <c>sh -c '…'</c> block, so <paramref name="dotnetExe"/> is shell-double-
-		/// quoted to survive the inner shell's re-interpretation of <c>$</c>/backtick/<c>\</c>/<c>"</c>
-		/// and to keep paths with spaces as one token.
+		/// Two variants exist because the interactive sudo consumer still accepts a rendered
+		/// argument string. Shell and graphical consumers accept a typed argument list and
+		/// apply their own escaping.
 		/// </summary>
 		static string[] BuildEnglishCliSudoArgsForShell(string dotnetExe, string[] args)
 		{
 			var result = new List<string>(args.Length + WorkloadCliEnv.Count + 1);
 			foreach (var kv in WorkloadCliEnv)
 				result.Add($"{kv.Key}={kv.Value}");
-			result.Add(Util.ShellDoubleQuote(dotnetExe));
+			result.Add(dotnetExe);
 			result.AddRange(args);
 			return result.ToArray();
 		}
@@ -115,7 +112,7 @@ namespace DotNetCheck.DotNet
 			foreach (var kv in WorkloadCliEnv)
 				result.Add($"{kv.Key}={kv.Value}");
 			result.Add(Util.QuoteForProcessArgs(dotnetExe));
-			result.AddRange(args);
+			result.AddRange(args.Select(Util.QuoteForProcessArgs));
 			return result.ToArray();
 		}
 
@@ -174,10 +171,14 @@ namespace DotNetCheck.DotNet
 				"workload",
 				"install",
 				"--from-rollback-file",
-				$"\"{rollbackFile}\""
+				rollbackFile
 			};
 			args.AddRange(workloadIds);
-			args.AddRange(packageSources.Select(ps => $"{addSourceArg} \"{ps}\""));
+			foreach (var packageSource in packageSources)
+			{
+				args.Add(addSourceArg);
+				args.Add(packageSource);
+			}
 
 			if (verbose)
 			{
@@ -199,7 +200,11 @@ namespace DotNetCheck.DotNet
 				"workload",
 				"repair"
 			};
-			args.AddRange(packageSources.Select(ps => $"{addSourceArg} \"{ps}\""));
+			foreach (var packageSource in packageSources)
+			{
+				args.Add(addSourceArg);
+				args.Add(packageSource);
+			}
 
 			if (verbose)
 			{
@@ -497,6 +502,18 @@ namespace DotNetCheck.DotNet
 		/// </summary>
 		async Task<ShellProcessRunner.ShellProcessResult> RetryWithSudo(string dotnetExe, CancellationToken cancellationToken, string[] args)
 		{
+			// Structured macOS hosts opt into the system authorization dialog. Do not use
+			// an unrelated Terminal sudo ticket: authorization belongs to this fix request.
+			if (Util.UseMacOsAdministratorPrompt)
+			{
+				return await Util.WrapShellCommandWithSudo(
+					"env",
+					DotNetCliWorkingDir,
+					Util.Verbose,
+					cancellationToken,
+					BuildEnglishCliSudoArgsForShell(dotnetExe, args));
+			}
+
 			// Always try non-interactive sudo first (works with cached credentials or NOPASSWD).
 			// Invoke through `env` so DOTNET_CLI_UI_LANGUAGE survives sudo's default env_reset —
 			// see WorkloadCliEnv for the full rationale. The two sudo helpers tokenize args

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -504,6 +504,9 @@ namespace DotNetCheck.DotNet
 		{
 			// Structured macOS/Linux hosts opt into the system authorization dialog. Do not
 			// use an unrelated terminal sudo ticket: authorization belongs to this fix request.
+			// Deliberate trade: a user who just authenticated in a terminal still gets the
+			// dialog, and each protected command is its own authorization — a workload
+			// repair + install can prompt twice for one fix (recorded in spec 003's host flow).
 			if (Util.UseAdministratorPrompt)
 			{
 				return await Util.WrapShellCommandWithSudo(

--- a/UnoCheck/Process/LinuxAdministratorCommandRunner.cs
+++ b/UnoCheck/Process/LinuxAdministratorCommandRunner.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace DotNetCheck
+{
+	/// <summary>
+	/// Runs one command through the Linux polkit authorization dialog (pkexec).
+	/// The containing Uno.Check process remains in the original user's context.
+	/// pkexec receives the program and its arguments as a typed argument vector —
+	/// no shell is involved, so argument boundaries are preserved as-is.
+	/// </summary>
+	internal static class LinuxAdministratorCommandRunner
+	{
+		static readonly string[] PkexecPaths = { "/usr/bin/pkexec", "/bin/pkexec" };
+
+		public static ShellProcessRunner.ShellProcessResult Run(
+			string executable,
+			string workingDirectory,
+			bool verbose,
+			CancellationToken cancellationToken,
+			IReadOnlyList<string> arguments)
+		{
+			if (!Util.IsLinux)
+				throw new PlatformNotSupportedException("The polkit authorization dialog is only available on Linux.");
+
+			var pkexec = PkexecPaths.FirstOrDefault(File.Exists)
+				?? throw new FileNotFoundException(
+					"The polkit authorization tool (pkexec) was not found. Install the polkit package for your distribution.",
+					PkexecPaths[0]);
+
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var runner = new ShellProcessRunner(new ShellProcessRunnerOptions(pkexec, string.Empty, cancellationToken)
+			{
+				ArgumentList = BuildArguments(executable, arguments),
+				WorkingDirectory = workingDirectory,
+				Verbose = verbose,
+				UseSystemShell = false,
+				RedirectOutput = true,
+			});
+
+			var result = runner.WaitForExit();
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (WasDeclined(result))
+			{
+				return new ShellProcessRunner.ShellProcessResult(
+					result.StandardOutput,
+					new List<string> { "Administrator approval was declined." },
+					result.ExitCode);
+			}
+
+			return result;
+		}
+
+		internal static IReadOnlyList<string> BuildArguments(string executable, IEnumerable<string> arguments)
+		{
+			if (string.IsNullOrWhiteSpace(executable))
+				throw new ArgumentException("An executable is required.", nameof(executable));
+
+			var argumentList = new List<string> { executable };
+			argumentList.AddRange(arguments ?? Array.Empty<string>());
+			return argumentList;
+		}
+
+		/// <summary>
+		/// pkexec exits with 126 when the user dismisses the authentication dialog and
+		/// writes "Request dismissed" to stderr; 127 covers authorization failures.
+		/// Only the explicit dismissal is normalized — other failures keep their output.
+		/// </summary>
+		internal static bool WasDeclined(ShellProcessRunner.ShellProcessResult result)
+		{
+			if (result == null || result.Success)
+				return false;
+
+			if (result.ExitCode == 126)
+				return true;
+
+			var output = result.StandardOutput.Concat(result.StandardError);
+			return output.Any(line =>
+				line?.IndexOf("Request dismissed", StringComparison.OrdinalIgnoreCase) >= 0);
+		}
+	}
+}

--- a/UnoCheck/Process/MacOsAdministratorCommandRunner.cs
+++ b/UnoCheck/Process/MacOsAdministratorCommandRunner.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace DotNetCheck
+{
+	/// <summary>
+	/// Runs one command through the macOS system administrator authorization dialog.
+	/// The containing Uno.Check process remains in the original user's context.
+	/// </summary>
+	internal static class MacOsAdministratorCommandRunner
+	{
+		const string OsascriptPath = "/usr/bin/osascript";
+		const string RunHandler = "on run argv";
+		const string ElevatedCommand = "do shell script (item 1 of argv) with administrator privileges with prompt \"Uno.Check needs administrator access to apply this fix.\"";
+		const string EndHandler = "end run";
+
+		public static ShellProcessRunner.ShellProcessResult Run(
+			string executable,
+			string workingDirectory,
+			bool verbose,
+			CancellationToken cancellationToken,
+			IReadOnlyList<string> arguments)
+		{
+			if (!Util.IsMac)
+				throw new PlatformNotSupportedException("The macOS administrator dialog is only available on macOS.");
+
+			if (!File.Exists(OsascriptPath))
+				throw new FileNotFoundException("The macOS administrator authorization tool was not found.", OsascriptPath);
+
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var commandLine = BuildCommandLine(executable, arguments);
+			var runner = new ShellProcessRunner(new ShellProcessRunnerOptions(OsascriptPath, string.Empty, cancellationToken)
+			{
+				ArgumentList = new[] { "-e", RunHandler, "-e", ElevatedCommand, "-e", EndHandler, "--", commandLine },
+				WorkingDirectory = workingDirectory,
+				Verbose = verbose,
+				UseSystemShell = false,
+				RedirectOutput = true,
+			});
+
+			var result = runner.WaitForExit();
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (WasDeclined(result))
+			{
+				return new ShellProcessRunner.ShellProcessResult(
+					result.StandardOutput,
+					new List<string> { "Administrator approval was declined." },
+					result.ExitCode);
+			}
+
+			return result;
+		}
+
+		internal static string BuildCommandLine(string executable, IEnumerable<string> arguments)
+		{
+			if (string.IsNullOrWhiteSpace(executable))
+				throw new ArgumentException("An executable is required.", nameof(executable));
+
+			var command = new List<string> { PosixShellQuote(executable) };
+			command.AddRange((arguments ?? Array.Empty<string>()).Select(PosixShellQuote));
+			return string.Join(" ", command);
+		}
+
+		internal static string PosixShellQuote(string value)
+			=> "'" + (value ?? string.Empty).Replace("'", "'\"'\"'") + "'";
+
+		internal static bool WasDeclined(ShellProcessRunner.ShellProcessResult result)
+		{
+			if (result == null || result.Success)
+				return false;
+
+			var output = result.StandardOutput.Concat(result.StandardError);
+			return output.Any(line =>
+				line?.IndexOf("User canceled", StringComparison.OrdinalIgnoreCase) >= 0
+				|| line?.IndexOf("User cancelled", StringComparison.OrdinalIgnoreCase) >= 0
+				|| line?.IndexOf("(-128)", StringComparison.OrdinalIgnoreCase) >= 0);
+		}
+	}
+}

--- a/UnoCheck/Process/ShellProcessRunner.cs
+++ b/UnoCheck/Process/ShellProcessRunner.cs
@@ -26,6 +26,7 @@ namespace DotNetCheck
 		 
 		public string Executable { get; set; }
 		public string Args { get; set; }
+		public IReadOnlyList<string> ArgumentList { get; set; }
 
 		public bool Verbose { get;set; }
 
@@ -79,6 +80,9 @@ namespace DotNetCheck
 
 			if (Options.UseSystemShell)
 			{
+				if (Options.ArgumentList != null)
+					throw new ArgumentException("ArgumentList cannot be combined with UseSystemShell.", nameof(options));
+
 				string tmpFile = null;
 
 				if (!Util.IsWindows)
@@ -95,7 +99,15 @@ namespace DotNetCheck
 			else
 			{
 				process.StartInfo.FileName = Options.Executable;
-				process.StartInfo.Arguments = Options.Args;
+				if (Options.ArgumentList == null)
+				{
+					process.StartInfo.Arguments = Options.Args;
+				}
+				else
+				{
+					foreach (var argument in Options.ArgumentList)
+						process.StartInfo.ArgumentList.Add(argument);
+				}
 			}
 
 			process.StartInfo.UseShellExecute = false;

--- a/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
+++ b/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
@@ -57,14 +57,43 @@ namespace DotNetCheck.Solutions
 			};
 
 			var args = Util.IsWindows
-					? $"\"{scriptPath}\" -InstallDir \"{sdkRoot}\" -Version \"{Version}\""
-					: $"\"{scriptPath}\" --install-dir \"{sdkRoot}\" --version \"{Version}\"";
+				? new[] { Util.QuoteForProcessArgs(scriptPath), "-InstallDir", Util.QuoteForProcessArgs(sdkRoot), "-Version", Version }
+				: new[] { scriptPath, "--install-dir", sdkRoot, "--version", Version };
 
 			Util.Log($"Executing dotnet-install script...");
-			Util.Log($"\t{exe} {args}");
+			Util.Log($"\t{exe} {string.Join(" ", args)}");
 
-			// Launch the process
-			await Util.WrapShellCommandWithSudo(exe, [args]);
+			// A user-local SDK install stays in the user's context. Only a protected
+			// DOTNET_ROOT is elevated, and then only the install command itself.
+			var result = !Util.IsWindows && IsDirectoryWritableOrCreatable(sdkRoot)
+				? await Util.ShellCommand(exe, workingDir: null, verbose: Util.Verbose, cancellationToken: cancellationToken, args: args)
+				: await Util.WrapShellCommandWithSudo(exe, workingDir: null, verbose: Util.Verbose, cancellationToken: cancellationToken, args: args);
+			if (!result.Success)
+				throw new InvalidOperationException(result.GetOutput());
+		}
+
+		internal static bool IsDirectoryWritableOrCreatable(string path)
+		{
+			var candidate = path;
+			while (!string.IsNullOrEmpty(candidate) && !Directory.Exists(candidate))
+				candidate = Path.GetDirectoryName(candidate);
+
+			if (string.IsNullOrEmpty(candidate))
+				return false;
+
+			var probe = Path.Combine(candidate, $".uno-check-write-{Guid.NewGuid():N}");
+			try
+			{
+				using (File.Create(probe))
+				{
+				}
+				File.Delete(probe);
+				return true;
+			}
+			catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+			{
+				return false;
+			}
 		}
 	}
 }

--- a/UnoCheck/Solutions/LinuxGitSolution.cs
+++ b/UnoCheck/Solutions/LinuxGitSolution.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 using DotNetCheck.Models;
@@ -9,9 +9,14 @@ namespace DotNetCheck.Solutions
 	{
 		public override async Task Implement(SharedState state, CancellationToken ct)
 		{
-			await Util.WrapShellCommandWithSudo("apt", workingDir: null, verbose: true, new[] { "update" });
-
-			await Util.WrapShellCommandWithSudo("apt", workingDir: null, verbose: true, new[] { "install", "git" });
+			// One elevated invocation for the whole fix: update && install as a single
+			// shell chain, so the graphical authorization flow (pkexec) shows one dialog
+			// instead of one per apt command.
+			await Util.WrapShellCommandWithSudo(
+				"/bin/sh",
+				workingDir: null,
+				verbose: true,
+				new[] { "-c", "apt-get update && apt-get install -y git" });
 		}
 	}
 }

--- a/UnoCheck/Solutions/LinuxNinjaSolution.cs
+++ b/UnoCheck/Solutions/LinuxNinjaSolution.cs
@@ -1,4 +1,4 @@
-﻿using DotNetCheck.Models;
+using DotNetCheck.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,8 +10,12 @@ namespace DotNetCheck.Solutions
 		{
 			await base.Implement(sharedState, cancellationToken);
 
-			_ = await Util.WrapShellCommandWithSudo("apt-get", new[] { "update" });
-			_ = await Util.WrapShellCommandWithSudo("apt-get", new[] { "install", "ninja-build" });
+			// One elevated invocation for the whole fix: update && install as a single
+			// shell chain, so the graphical authorization flow (pkexec) shows one dialog
+			// instead of one per apt command.
+			_ = await Util.WrapShellCommandWithSudo(
+				"/bin/sh",
+				new[] { "-c", "apt-get update && apt-get install -y ninja-build" });
 
 			ReportStatus("Ninja Build System was installed on Linux.");
 		}

--- a/UnoCheck/Solutions/LinuxOtherDistGitCliSolution.cs
+++ b/UnoCheck/Solutions/LinuxOtherDistGitCliSolution.cs
@@ -1,4 +1,4 @@
-﻿using DotNetCheck.Models;
+using DotNetCheck.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,7 +10,15 @@ namespace DotNetCheck.Solutions
 		{
 			await base.Implement(sharedState, cancellationToken);
 
-			var r = await Util.WrapShellCommandWithSudo("x-www-browser", new[] { GitOpenUrl });
+			// Opening a browser needs the user's session, not root: elevation wrappers
+			// (sudo/pkexec) strip DISPLAY/WAYLAND_DISPLAY, so an elevated launch fails
+			// after authentication and the prompt only confuses.
+			var r = await Util.ShellCommand(
+				"x-www-browser",
+				workingDir: null,
+				verbose: Util.Verbose,
+				cancellationToken,
+				new[] { GitOpenUrl });
 
 			if (r.ExitCode == 0)
 			{

--- a/UnoCheck/Solutions/XcodeEulaSolution.cs
+++ b/UnoCheck/Solutions/XcodeEulaSolution.cs
@@ -11,7 +11,9 @@ namespace DotNetCheck.Solutions
 		{
 			await base.Implement(sharedState, cancellationToken);
 
-			_ = await Util.WrapShellCommandWithSudo("xcodebuild", new[] { "-license", "accept" });
+			var result = await Util.WrapShellCommandWithSudo("/usr/bin/xcodebuild", new[] { "-license", "accept" });
+			if (!result.Success)
+				throw new InvalidOperationException(result.GetOutput());
 		}
 	}
 }

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -70,6 +70,21 @@ namespace DotNetCheck
 		internal static bool ShouldUseMacOsAdministratorPrompt(bool isMac, bool ci, bool structuredOutput, bool allowElevationPrompt)
 			=> isMac && !ci && structuredOutput && allowElevationPrompt;
 
+		/// <summary>
+		/// Linux analog of <see cref="UseMacOsAdministratorPrompt"/>: the polkit dialog
+		/// (pkexec) authorizes the individual command on structured desktop hosts.
+		/// CI remains strictly non-interactive.
+		/// </summary>
+		public static bool UseLinuxAdministratorPrompt
+			=> ShouldUseLinuxAdministratorPrompt(IsLinux, CI, Json.JsonlOutput.Enabled, AllowElevationPrompt);
+
+		internal static bool ShouldUseLinuxAdministratorPrompt(bool isLinux, bool ci, bool structuredOutput, bool allowElevationPrompt)
+			=> isLinux && !ci && structuredOutput && allowElevationPrompt;
+
+		/// <summary>Any platform-native per-command authorization dialog is active.</summary>
+		public static bool UseAdministratorPrompt
+			=> UseMacOsAdministratorPrompt || UseLinuxAdministratorPrompt;
+
 		public static Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
 
 		public static Platform Platform
@@ -251,6 +266,16 @@ namespace DotNetCheck
 			if (!noPrompt && UseMacOsAdministratorPrompt)
 			{
 				return Task.FromResult(MacOsAdministratorCommandRunner.Run(
+					cmd,
+					workingDir,
+					verbose,
+					cancellationToken,
+					args));
+			}
+
+			if (!noPrompt && UseLinuxAdministratorPrompt)
+			{
+				return Task.FromResult(LinuxAdministratorCommandRunner.Run(
 					cmd,
 					workingDir,
 					verbose,
@@ -648,6 +673,22 @@ namespace DotNetCheck
 				{
 					var elevatedResult = MacOsAdministratorCommandRunner.Run(
 						ShellProcessRunner.MacOSShell,
+						workingDirectory: null,
+						verbose: Verbose,
+						cancellationToken: System.Threading.CancellationToken.None,
+						arguments: new[] { "-c", copyCommand });
+
+					if (!elevatedResult.Success)
+						throw new InvalidOperationException(elevatedResult.GetOutput());
+
+					return true;
+				}
+
+				if (UseLinuxAdministratorPrompt)
+				{
+					// pkexec takes argv directly; the shell here only carries the && chain.
+					var elevatedResult = LinuxAdministratorCommandRunner.Run(
+						"/bin/sh",
 						workingDirectory: null,
 						verbose: Verbose,
 						cancellationToken: System.Threading.CancellationToken.None,

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -57,6 +57,18 @@ namespace DotNetCheck
 		public static string LogFile { get; set; }
 		public static bool CI { get; set; }
 		public static bool NonInteractive { get; set; }
+		public static bool AllowElevationPrompt { get; set; }
+
+		/// <summary>
+		/// Structured hosts cannot provide a terminal for sudo. On macOS, use the system
+		/// administrator authorization dialog for the individual command instead.
+		/// CI remains strictly non-interactive.
+		/// </summary>
+		public static bool UseMacOsAdministratorPrompt
+			=> ShouldUseMacOsAdministratorPrompt(IsMac, CI, Json.JsonlOutput.Enabled, AllowElevationPrompt);
+
+		internal static bool ShouldUseMacOsAdministratorPrompt(bool isMac, bool ci, bool structuredOutput, bool allowElevationPrompt)
+			=> isMac && !ci && structuredOutput && allowElevationPrompt;
 
 		public static Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
 
@@ -209,7 +221,13 @@ namespace DotNetCheck
 
 		public static Task<ShellProcessRunner.ShellProcessResult> ShellCommand(string cmd, string workingDir, bool verbose, System.Threading.CancellationToken cancellationToken, string[] args)
 		{
-			var cli = new ShellProcessRunner(new ShellProcessRunnerOptions(cmd, string.Join(" ", args), cancellationToken) { WorkingDirectory = workingDir, Verbose = verbose } );
+			var cli = new ShellProcessRunner(new ShellProcessRunnerOptions(cmd, string.Empty, cancellationToken)
+			{
+				ArgumentList = args,
+				WorkingDirectory = workingDir,
+				Verbose = verbose,
+				UseSystemShell = false,
+			});
 			return Task.FromResult(cli.WaitForExit());
 		}
 
@@ -230,6 +248,16 @@ namespace DotNetCheck
 
 		public static Task<ShellProcessRunner.ShellProcessResult> WrapShellCommandWithSudo(string cmd, string workingDir, bool verbose, System.Threading.CancellationToken cancellationToken, bool noPrompt, string[] args)
 		{
+			if (!noPrompt && UseMacOsAdministratorPrompt)
+			{
+				return Task.FromResult(MacOsAdministratorCommandRunner.Run(
+					cmd,
+					workingDir,
+					verbose,
+					cancellationToken,
+					args));
+			}
+
 			var actualCmd = cmd;
 			var actualArgs = string.Join(" ", args);
 
@@ -242,11 +270,10 @@ namespace DotNetCheck
 				// shell once the outer `'...'` block is unwrapped. Without this, sudo retries on
 				// such installs fail with "command not found".
 				var quotedCmd = ShellDoubleQuote(cmd);
-				// Args are interpolated raw into the outer single-quoted block, so escape any
-				// embedded single quotes so they don't terminate the block early. Per-arg spaces
-				// are the caller's responsibility (e.g., BuildInstallArgs pre-wraps paths with
-				// inner double quotes).
-				var escapedArgs = actualArgs.Replace("'", "'\\''");
+				// Quote every argument before interpolation. These quotes become syntax for
+				// the command executed by the shell and prevent argument injection.
+				var quotedArgs = string.Join(" ", args.Select(MacOsAdministratorCommandRunner.PosixShellQuote));
+				var escapedArgs = quotedArgs.Replace("'", "'\\''");
 				actualArgs = $"-c '{sudoPrefix} {quotedCmd} {escapedArgs}'";
 			}
 
@@ -610,14 +637,34 @@ namespace DotNetCheck
 
 			if (r && !Util.IsWindows)
 			{
+				var quotedDestDir = MacOsAdministratorCommandRunner.PosixShellQuote(destDir);
+				var quotedIntermediate = MacOsAdministratorCommandRunner.PosixShellQuote(intermediate);
+				var quotedDestination = MacOsAdministratorCommandRunner.PosixShellQuote(destination);
+				var copyCommand = isFile
+					? $"mkdir -p {quotedDestDir} && cp -pP {quotedIntermediate} {quotedDestination}"
+					: $"mkdir -p {quotedDestDir} && cp -pPR {quotedIntermediate}/ {quotedDestination}";
+
+				if (UseMacOsAdministratorPrompt)
+				{
+					var elevatedResult = MacOsAdministratorCommandRunner.Run(
+						ShellProcessRunner.MacOSShell,
+						workingDirectory: null,
+						verbose: Verbose,
+						cancellationToken: System.Threading.CancellationToken.None,
+						arguments: new[] { "-c", copyCommand });
+
+					if (!elevatedResult.Success)
+						throw new InvalidOperationException(elevatedResult.GetOutput());
+
+					return true;
+				}
+
 				// Copy a file to a destination as su
 				//		sudo mkdir -p destDir && sudo cp -pP intermediate destination
 
 				// Copy a folder recursively to the destination as su
 				//		sudo mkdir -p destDir && sudo cp -pPR intermediate/ destination
-				var args = isFile
-					? $"-c 'sudo mkdir -p \"{destDir}\" && sudo cp -pP \"{intermediate}\" \"{destination}\"'"
-					: $"-c 'sudo mkdir -p \"{destDir}\" && sudo cp -pPR \"{intermediate}/\" \"{destination}\"'"; // note the / at the end of the dir
+				var args = $"-c 'sudo {copyCommand.Replace("'", "'\\''")}'";
 
 				if (Verbose)
 					Console.WriteLine($"{ShellProcessRunner.MacOSShell} {args}");

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -204,6 +204,16 @@ Structured-output events carry a `correlation_id`, newly generated per run by de
 uno-check --fix --only androidsdk --json-file "%TEMP%\uno-check-fix-1234.jsonl" --correlation-id 6f2c1b6e
 ```
 
+### `--allow-elevation-prompt` Allow macOS administrator authorization
+
+Allows a structured macOS fix run to display the system administrator authorization dialog when an individual solution needs to modify a protected location. Uno.Check itself remains in the current user's context; only the underlying command is authorized as an administrator. Declining the dialog produces a failed `fix_result` and the check remains unresolved.
+
+This option is opt-in because `--json` is also used by unattended consumers. It is ignored with `--ci`, and it does not change the existing interactive Terminal `sudo` flow.
+
+```bash
+uno-check --fix --only xcode --json --allow-elevation-prompt
+```
+
 ### Exit codes
 
 | Code | Meaning |

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -176,6 +176,9 @@ uno-check --fix --only androidsdk --non-interactive
 > [!NOTE]
 > An id that matches no checkup fails the run: the unknown ids are listed on stderr and the exit code is non-zero, so a typo can never produce a passing empty run.
 
+> [!NOTE]
+> With `--fix --non-interactive`, only the checkups named by `--only` are auto-fixed. Dependency checkups pulled into the run are examined for context but never fixed — a fix (and any elevation it needs) always corresponds to the checkup the caller requested. Interactive runs still confirm each fix individually.
+
 ### `--json` Structured JSONL output
 
 Emits machine-readable JSONL on stdout — one JSON event per line (`run_started`, `checkup_started`, `checkup_progress`, `checkup_result`, `fix_started`, `fix_progress`, `fix_result`) ending with a final `report` event containing the full results and summary. The `report` event is emitted on every exit path — including cancellation and early failures — so consumers can treat it as the end-of-stream marker. Human-readable output moves to stderr so stdout stays pure JSONL. Implies `--non-interactive`.

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -204,11 +204,16 @@ Structured-output events carry a `correlation_id`, newly generated per run by de
 uno-check --fix --only androidsdk --json-file "%TEMP%\uno-check-fix-1234.jsonl" --correlation-id 6f2c1b6e
 ```
 
-### `--allow-elevation-prompt` Allow macOS administrator authorization
+### `--allow-elevation-prompt` Allow macOS / Linux authorization dialogs
 
-Allows a structured macOS fix run to display the system administrator authorization dialog when an individual solution needs to modify a protected location. Uno.Check itself remains in the current user's context; only the underlying command is authorized as an administrator. Declining the dialog produces a failed `fix_result` and the check remains unresolved.
+Allows a structured macOS or Linux fix run to display the system authorization dialog when an individual solution needs to modify a protected location. Uno.Check itself remains in the current user's context; only the underlying command is authorized:
 
-This option is opt-in because `--json` is also used by unattended consumers. It is ignored with `--ci`, and it does not change the existing interactive Terminal `sudo` flow.
+- **macOS** shows the system administrator authorization dialog.
+- **Linux** shows the polkit authentication dialog via `pkexec` (a polkit authentication agent must be running, as on any desktop session). If `pkexec` is not installed, the fix fails with a message naming the missing tool.
+
+Declining either dialog produces a failed `fix_result` (`Administrator approval was declined.`) and the check remains unresolved.
+
+This option is opt-in because `--json` is also used by unattended consumers. It is ignored with `--ci`, and it does not change the existing interactive terminal `sudo` flow.
 
 ```bash
 uno-check --fix --only xcode --json --allow-elevation-prompt

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -178,6 +178,7 @@ uno-check --fix --only androidsdk --non-interactive
 
 > [!NOTE]
 > With `--fix --non-interactive`, only the checkups named by `--only` are auto-fixed. Dependency checkups pulled into the run are examined for context but never fixed — a fix (and any elevation it needs) always corresponds to the checkup the caller requested. Interactive runs still confirm each fix individually.
+> Consequently, a host fixing several items in one child must name every selected id (`--only a --only b …`) instead of relying on a dependency to pull the rest in — which also keeps authorization prompts to exactly the items the user selected. A full-run `--fix` without `--only` still fixes everything it examines.
 
 ### `--json` Structured JSONL output
 

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -31,7 +31,9 @@ package:
    so the host tails the file instead.
 3. **`--only <checkup-id>`** — scope the run to the named checkup(s) plus their required
    dependencies (caller ids match exactly, case-insensitively; dependency ids keep the existing
-   one-way prefix rule). Repeatable.
+   one-way prefix rule). Repeatable. With `--fix --non-interactive`, only caller-named
+   checkups are auto-fixed: dependencies are examined for context but never fixed, so a
+   host-side elevation prompt always describes the fix the user requested.
 4. **`--allow-elevation-prompt`** — opt a structured macOS or Linux fix run into the system
    authorization dialog (macOS administrator prompt; Linux polkit via `pkexec`). Only the
    command requested by the active solution is elevated; the Uno.Check process and its

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -32,10 +32,11 @@ package:
 3. **`--only <checkup-id>`** — scope the run to the named checkup(s) plus their required
    dependencies (caller ids match exactly, case-insensitively; dependency ids keep the existing
    one-way prefix rule). Repeatable.
-4. **`--allow-elevation-prompt`** — opt a structured macOS fix run into the system
-   administrator authorization dialog. Only the command requested by the active solution is
-   elevated; the Uno.Check process and its user-scoped path discovery remain unelevated. The
-   option is ignored in CI and does not affect the existing Terminal sudo flow.
+4. **`--allow-elevation-prompt`** — opt a structured macOS or Linux fix run into the system
+   authorization dialog (macOS administrator prompt; Linux polkit via `pkexec`). Only the
+   command requested by the active solution is elevated; the Uno.Check process and its
+   user-scoped path discovery remain unelevated. The option is ignored in CI and does not
+   affect the existing terminal sudo flow.
 
 ### Open question — execution level (deferred, needs maintainer sign-off)
 
@@ -142,7 +143,10 @@ checks failed.
    - On macOS, keep the same current-user JSON process and add `--allow-elevation-prompt`.
      User-level solutions run without a prompt. A solution that needs a protected location
      displays the system administrator dialog and elevates only its underlying command.
-   The terminal `report` marks the end of either child stream.
+   - On Linux, the same flag routes protected commands through the polkit dialog (`pkexec`),
+     which needs a running polkit authentication agent (present on any desktop session).
+     Declining the dialog — or a missing `pkexec` — surfaces as a failed `fix_result`.
+   The terminal `report` marks the end of any child stream.
 
 Host requirements:
 

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -32,6 +32,10 @@ package:
 3. **`--only <checkup-id>`** — scope the run to the named checkup(s) plus their required
    dependencies (caller ids match exactly, case-insensitively; dependency ids keep the existing
    one-way prefix rule). Repeatable.
+4. **`--allow-elevation-prompt`** — opt a structured macOS fix run into the system
+   administrator authorization dialog. Only the command requested by the active solution is
+   elevated; the Uno.Check process and its user-scoped path discovery remain unelevated. The
+   option is ignored in CI and does not affect the existing Terminal sudo flow.
 
 ### Open question — execution level (deferred, needs maintainer sign-off)
 
@@ -130,10 +134,15 @@ checks failed.
    (`--ci` additionally enables strict manifest-version validation — appropriate when the host
    pins a released tool version, wrong for local dev builds.)
 2. Render per-check cards live from `checkup_*` events; summary from `report`.
-3. Fix one item: launch elevated `uno-check --fix --only <id> --non-interactive
-   --json-file <fresh-path> --correlation-id <this run's id>` using `fix.args` from the
-   check's result; tail the file for `fix_*` events and the fix child's own re-examined
-   `checkup_result`; the terminal `report` marks the end of the child's stream.
+3. Fix one item:
+   - On Windows, launch elevated `uno-check --fix --only <id> --non-interactive
+     --json-file <fresh-path> --correlation-id <this run's id>` using `fix.args` from the
+     check's result; tail the file for `fix_*` events and the fix child's own re-examined
+     `checkup_result`.
+   - On macOS, keep the same current-user JSON process and add `--allow-elevation-prompt`.
+     User-level solutions run without a prompt. A solution that needs a protected location
+     displays the system administrator dialog and elevates only its underlying command.
+   The terminal `report` marks the end of either child stream.
 
 Host requirements:
 

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -150,15 +150,40 @@ checks failed.
      Declining the dialog — or a missing `pkexec` — surfaces as a failed `fix_result`.
    The terminal `report` marks the end of any child stream.
 
+   Authorization-dialog expectations for hosts:
+
+   - **Each protected command is its own authorization.** A single fix can prompt more than
+     once — e.g. a root-owned SDK's workloads fix runs repair and install through separate
+     elevated commands, so two dialogs. A "fix all" flow prompts the sum across items.
+     Solutions coalesce where they can (the apt-based fixes chain update+install into one
+     elevated shell), but hosts should not promise one dialog per fix.
+   - **The elevated command runs as root, not the user.** Per-user state the command touches
+     (NuGet caches, first-run sentinels) therefore lands by `HOME`: on Linux `pkexec` sets a
+     root `HOME` and scrubs the environment (the workload path re-injects what it needs via
+     `env`; on-host runs show root-owned artifacts under the system dotnet root). On macOS
+     the equivalent `HOME` under `do shell script … with administrator privileges` has not
+     been captured yet — either outcome is benign: root's home means a cold cache (slower),
+     the user's home means root-owned cache entries, same as the previous macOS `sudo` path.
+     Worth recording the observed value when next on a macOS host.
+   - **A cached terminal `sudo` ticket is deliberately not reused**: authorization belongs to
+     the fix the user clicked, so the dialog appears even right after a terminal `sudo`.
+
 Host requirements:
 
 - Drain stderr as well as stdout, or leave stderr unredirected: in `--json` mode the whole
   human-readable UI moves there, and an undrained pipe stalls the run once its buffer fills.
 - Treat process exit as an end-of-stream signal alongside `report`: an argument-parse failure
   produces no events and, on Windows, happens after the child's console has been hidden.
-- `fix.args` for an item scopes the run to that item **plus its required dependencies**, and
-  `--fix` applies to every checkup in the run — fixing the emulator can install the Android
-  SDK and JDK first. Surface that in the UI rather than promising a single-item change.
+- `fix.args` for an item scopes the run to that item **plus its required dependencies**, but
+  with `--only` present, `--fix --non-interactive` applies fixes **only to caller-named ids**
+  — dependencies are examined for context, never fixed. Two host-facing consequences:
+  - An item whose prerequisite is itself broken can resolve as `skipped` (dependency failure)
+    instead of fixed — the card goes from "Fix" to "skipped" with no visible progress unless
+    the host explains that the prerequisite must be fixed first.
+  - A "fix all" (or multi-item) flow must name **every** selected id (`--only a --only b …`)
+    rather than relying on dependency pull-in — which also keeps authorization prompts to
+    exactly the items the user selected. A full-run `--fix` without `--only` still fixes
+    everything it examines.
 
 ## Consumers
 


### PR DESCRIPTION
## Summary

- add an opt-in `--allow-elevation-prompt` flag for structured macOS fix runs
- authorize only protected commands through the native macOS administrator dialog while keeping user-scoped fixes unelevated
- preserve process argument boundaries and report declined authorization as a failed fix result
- cover command quoting, prompt selection, argument handling, and SDK install-path behavior with tests

## Validation

- `dotnet test UnoCheck.Tests/UnoCheck.Tests.csproj -c Release --filter "FullyQualifiedName~MacOsAdministratorCommandRunnerTests|FullyQualifiedName~DotNetSdkScriptInstallSolutionTests|FullyQualifiedName~ShellProcessRunnerTests|FullyQualifiedName~DotNetWorkloadFeedbackTests"` (86 passed)
- native macOS authorization dialog manually verified with a harmless command
- Release solution build completed with 0 errors; existing dependency, EOL target-framework, and analyzer warnings remain
- full suite: 248 passed, 1 existing platform-specific failure (`CheckCommandTests` expects `win32`, receives `skiadesktop` on macOS)

## Behavior

Structured macOS hosts can launch an individual fix with `--json --allow-elevation-prompt`. User-level fixes run normally. If a protected command is required, macOS displays its native administrator dialog; declining returns `Administrator approval was declined.` through the structured failed-fix flow. The flag is ignored in CI.