### PR TITLE
docs: spec 004 — reducing elevation prompts

### DIFF
--- a/UnoCheck.Tests/JsonStructuredOutputTests.cs
+++ b/UnoCheck.Tests/JsonStructuredOutputTests.cs
@@ -34,6 +34,22 @@ file class NoopSolution : Solution
 {
 }
 
+/// <summary>Solution with a caller-chosen elevation answer (or one that throws while deciding).</summary>
+file class ElevationSolution : Solution
+{
+    private readonly bool _requiresElevation;
+    private readonly bool _throws;
+
+    public ElevationSolution(bool requiresElevation, bool throws = false)
+    {
+        _requiresElevation = requiresElevation;
+        _throws = throws;
+    }
+
+    public override bool RequiresElevation
+        => _throws ? throw new UnauthorizedAccessException("probe failed") : _requiresElevation;
+}
+
 public class BuildHealthCheckTests
 {
     [Fact]
@@ -120,6 +136,28 @@ public class BuildHealthCheckTests
     }
 
     [Fact]
+    public void Unclassified_Solution_Requires_Elevation()
+    {
+        // The base default is conservative: a needless prompt beats a fix that fails
+        // halfway through because the host did not elevate.
+        var checkup = new FakeCheckup("hyperv");
+        var diagnosis = new DiagnosticResult(Status.Error, checkup, new Suggestion("Enable it", new NoopSolution()));
+
+        Assert.True(CheckCommand.BuildHealthCheck(checkup, diagnosis).Fix!.RequiresElevation);
+    }
+
+    [Fact]
+    public void User_Scoped_Solution_Does_Not_Require_Elevation()
+    {
+        // The point of the field: a host must not raise UAC for a fix that only writes
+        // per-user state (templates, the Uno SDK restore, a user-local SDK).
+        var checkup = new FakeCheckup("dotnetnewunotemplates");
+        var diagnosis = new DiagnosticResult(Status.Error, checkup, new Suggestion("Install", new ElevationSolution(false)));
+
+        Assert.False(CheckCommand.BuildHealthCheck(checkup, diagnosis).Fix!.RequiresElevation);
+    }
+
+    [Fact]
     public void Error_Without_Message_Falls_Back_To_Suggestion_Description()
     {
         // Some checkups (e.g. a workloads mismatch) report status without a message;
@@ -188,6 +226,67 @@ public class IsCallerNamedForFixTests
     {
         // Caller ids match exactly — the one-way prefix rule is for dependency ids only.
         Assert.False(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", ["dotnetworkloads"]));
+    }
+}
+
+public class RequiresElevationTests
+{
+    [Fact]
+    public void Any_Elevated_Solution_Makes_The_Whole_Fix_Elevated()
+    {
+        // A fix applies every solution behind the suggestion, so the host has to satisfy
+        // the strictest one — reporting false here would fail the fix midway.
+        var suggestion = new Suggestion("Mixed", new ElevationSolution(false), new ElevationSolution(true));
+
+        Assert.True(CheckCommand.RequiresElevation(suggestion));
+    }
+
+    [Fact]
+    public void All_User_Scoped_Solutions_Need_No_Elevation()
+    {
+        var suggestion = new Suggestion("User scoped", new ElevationSolution(false), new ElevationSolution(false));
+
+        Assert.False(CheckCommand.RequiresElevation(suggestion));
+    }
+
+    [Fact]
+    public void Suggestion_Without_Solutions_Needs_No_Elevation()
+    {
+        // Nothing to run, so nothing to elevate: an advice-only suggestion must not make a
+        // host prompt for a fix it cannot apply.
+        Assert.False(CheckCommand.RequiresElevation(new Suggestion("Manual steps only")));
+    }
+
+    [Fact]
+    public void A_Failing_Probe_Falls_Back_To_Requiring_Elevation()
+    {
+        // Deciding can touch the filesystem (SDK root writability); if that throws, the
+        // safe answer is the conservative one rather than an unelevated fix that fails.
+        var suggestion = new Suggestion("Probe throws", new ElevationSolution(false, throws: true));
+
+        Assert.True(CheckCommand.RequiresElevation(suggestion));
+    }
+
+    [Fact]
+    public void Known_User_Scoped_Solutions_Report_No_Elevation()
+    {
+        // These are the fixes a host was previously forced to elevate for no reason:
+        // per-user template store, per-user NuGet/temp restore, CurrentUser policy scope.
+        Assert.False(new DotNetCheck.Solutions.DotNetNewTemplatesInstallSolution(false, false).RequiresElevation);
+        Assert.False(new DotNetCheck.Solutions.UnoSdkSolution().RequiresElevation);
+        Assert.False(new DotNetCheck.Solutions.PSExecutionPolicySolution().RequiresElevation);
+        Assert.False(new DotNetCheck.Solutions.LinuxNinjaOpenUrlSolution().RequiresElevation);
+    }
+
+    [Fact]
+    public void Layout_Dependent_Solutions_Follow_The_Targets_Writability()
+    {
+        // The same workloads fix is elevated against a machine-wide SDK and unelevated
+        // against a user-local one, so the answer must come from the target, not the type.
+        var userLocal = new DotNetCheck.Solutions.DotNetWorkloadUpdateSolution(
+            Path.Combine(Path.GetTempPath(), "dotnet", "dotnet"));
+
+        Assert.False(userLocal.RequiresElevation);
     }
 }
 

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -723,6 +723,7 @@ namespace DotNetCheck.Cli
 						? diagnosis.Suggestion.Name
 						: $"{diagnosis.Suggestion.Name}: {diagnosis.Suggestion.Description}",
 					AutoFixable = fixable,
+					RequiresElevation = RequiresElevation(diagnosis.Suggestion),
 					Args = fixable
 						? new[] { "--fix", "--only", checkup.Id, "--non-interactive" }
 						: null,
@@ -748,6 +749,36 @@ namespace DotNetCheck.Cli
 				Message = message,
 				Fix = fix,
 			};
+		}
+
+		/// <summary>
+		/// A suggestion needs elevation when any of its solutions does — a fix applies them
+		/// all, so the host must elevate for the strictest one. A suggestion with no
+		/// solutions cannot be fixed at all, and reports false rather than an idle prompt.
+		/// Evaluating each solution may probe the filesystem (writability of an SDK root),
+		/// so a solution that throws is treated as elevation-requiring: the conservative
+		/// answer, matching the base default.
+		/// </summary>
+		internal static bool RequiresElevation(Suggestion suggestion)
+		{
+			if (suggestion?.Solutions is not { } solutions)
+				return false;
+
+			foreach (var solution in solutions)
+			{
+				try
+				{
+					if (solution.RequiresElevation)
+						return true;
+				}
+				catch (Exception ex)
+				{
+					Util.Exception(ex);
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		private void CheckupStatusUpdated(object sender, CheckupStatusEventArgs e)

--- a/UnoCheck/Checkups/AndroidEmulatorCheckup.cs
+++ b/UnoCheck/Checkups/AndroidEmulatorCheckup.cs
@@ -174,7 +174,9 @@ namespace DotNetCheck.Checkups
 							}
 
 							return Task.CompletedTask;
-						})).ToArray())));
+						},
+						// Creating an AVD writes the per-user Android home (~/.android).
+						requiresElevation: false)).ToArray())));
 		}
 	}
 

--- a/UnoCheck/Checkups/AndroidSdkCheckup.cs
+++ b/UnoCheck/Checkups/AndroidSdkCheckup.cs
@@ -255,7 +255,10 @@ For more information see: [underline]https://aka.ms/dotnet-androidsdk-help[/]";
 								}
 							}
 						}
-					}))));
+					},
+					// Packages install into the discovered Android SDK: the usual per-user
+					// location needs no elevation, a shared/Program Files one does.
+					requiresElevation: !Util.IsDirectoryWritable(sdkInstance.Path)))));
 
 		}
 

--- a/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
@@ -307,7 +307,10 @@ namespace DotNetCheck.Checkups
 					}
 
 					history.ContributeState(StateKey.EntryPoint, StateKey.ShouldRestartVs, true);
-				})));
+				},
+				// Workloads install into this SDK root: a machine-wide SDK needs elevation,
+				// a user-local one (DOTNET_ROOT, ~/.dotnet) does not.
+				requiresElevation: !Util.IsDirectoryWritable(SdkRoot))));
 		}
 	}
 }

--- a/UnoCheck/Checkups/HttpsDevCertCheckup.cs
+++ b/UnoCheck/Checkups/HttpsDevCertCheckup.cs
@@ -51,7 +51,11 @@ namespace DotNetCheck.Checkups
                         Directory.GetCurrentDirectory(),
                         Util.Verbose,
                         ["dev-certs", "https", "--trust"]);
-                })
+                },
+                // Windows/macOS trust the cert in the user's own store — the OS may still
+                // show its own trust confirmation, which is not elevation. Linux writes the
+                // system trust store and does need root.
+                requiresElevation: Util.IsLinux)
             );
 
             return new DiagnosticResult(Status.Error, this, suggestion);

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -504,6 +504,9 @@ namespace DotNetCheck.DotNet
 		{
 			// Structured macOS/Linux hosts opt into the system authorization dialog. Do not
 			// use an unrelated terminal sudo ticket: authorization belongs to this fix request.
+			// Deliberate trade: a user who just authenticated in a terminal still gets the
+			// dialog, and each protected command is its own authorization — a workload
+			// repair + install can prompt twice for one fix (recorded in spec 003's host flow).
 			if (Util.UseAdministratorPrompt)
 			{
 				return await Util.WrapShellCommandWithSudo(

--- a/UnoCheck/Json/JsonOutput.cs
+++ b/UnoCheck/Json/JsonOutput.cs
@@ -403,6 +403,18 @@ namespace DotNetCheck.Json
 		public bool AutoFixable { get; init; }
 
 		/// <summary>
+		/// Whether applying the fix needs administrator/root rights. Windows has no
+		/// per-command elevation, so a host must decide before launching whether to use the
+		/// <c>runas</c> verb; without this signal the only safe choice is to elevate every
+		/// fix. True when any solution behind the suggestion needs it, and conservative by
+		/// construction: a solution requires elevation unless it is known to write only
+		/// user-scoped state, and layout-dependent ones (the .NET SDK root, the Android SDK)
+		/// probe the actual target's writability rather than assuming.
+		/// </summary>
+		[JsonPropertyName("requires_elevation")]
+		public bool RequiresElevation { get; init; }
+
+		/// <summary>
 		/// Argument vector for a per-item fix, to be passed straight to the uno-check
 		/// process with no shell involved. Never a pre-joined command string: checkup
 		/// ids can embed manifest-sourced version text, and a joined string invites

--- a/UnoCheck/Models/Solution.cs
+++ b/UnoCheck/Models/Solution.cs
@@ -12,6 +12,20 @@ namespace DotNetCheck.Models
 		public virtual Task Implement(SharedState sharedState, System.Threading.CancellationToken cancellationToken)
 			=> Task.CompletedTask;
 
+		/// <summary>
+		/// Whether applying this solution needs administrator/root rights. Surfaced to
+		/// structured hosts as <c>fix.requires_elevation</c> so a host can decide, before
+		/// launching, whether the fix child needs elevation — Windows has no per-command
+		/// elevation, so without this signal a host must elevate every fix.
+		///
+		/// Defaults to <see langword="true"/>: an unclassified solution keeps today's
+		/// conservative behavior (a needless prompt is an annoyance; a missing one is a
+		/// failed fix). Solutions that only ever write user-scoped state override it to
+		/// <see langword="false"/>, and solutions whose target depends on the machine layout
+		/// compute it from that target's writability.
+		/// </summary>
+		public virtual bool RequiresElevation => true;
+
 		public void ReportStatus(string message)
 			=> OnStatusUpdated?.Invoke(this, new RemedyStatusEventArgs(this, message));
 

--- a/UnoCheck/Solutions/ActionSolution.cs
+++ b/UnoCheck/Solutions/ActionSolution.cs
@@ -7,12 +7,20 @@ namespace DotNetCheck.Solutions
 {
 	public class ActionSolution : Solution
 	{
-		public ActionSolution(Func<Solution, CancellationToken, Task> curer)
+		/// <param name="requiresElevation">
+		/// Whether the action needs administrator/root rights. Left at <see langword="true"/>
+		/// unless the call site knows the action only writes user-scoped state — see
+		/// <see cref="Solution.RequiresElevation"/>.
+		/// </param>
+		public ActionSolution(Func<Solution, CancellationToken, Task> curer, bool requiresElevation = true)
 		{
 			Curer = curer;
+			RequiresElevation = requiresElevation;
 		}
 
 		public Func<Solution, CancellationToken, Task> Curer { get; private set; }
+
+		public override bool RequiresElevation { get; }
 
 		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
 		{

--- a/UnoCheck/Solutions/DotNetNewTemplatesInstallSolution.cs
+++ b/UnoCheck/Solutions/DotNetNewTemplatesInstallSolution.cs
@@ -17,6 +17,12 @@ internal class DotNetNewTemplatesInstallSolution : Solution
     private readonly bool _uninstallExisting;
     private readonly NuGetVersion? _requestedVersion;
 
+    /// <summary>
+    /// <c>dotnet new install/uninstall</c> writes the per-user template engine store
+    /// (~/.templateengine), never a machine location.
+    /// </summary>
+    public override bool RequiresElevation => false;
+
     public DotNetNewTemplatesInstallSolution(
         bool uninstallLegacy, 
         bool uninstallExisting, 

--- a/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
+++ b/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
@@ -21,6 +21,29 @@ namespace DotNetCheck.Solutions
 		}
 
 		public readonly string Version;
+
+		/// <summary>
+		/// Depends on the machine layout: the default Windows root is under Program Files
+		/// (elevation required), while a DOTNET_ROOT or the unix default of ~/.dotnet is
+		/// user-writable. Probed rather than assumed, so a user-local SDK does not make a
+		/// host prompt needlessly.
+		/// </summary>
+		public override bool RequiresElevation => !Util.IsDirectoryWritable(DefaultSdkRoot());
+
+		/// <summary>
+		/// The root <see cref="Implement"/> installs into when SharedState carries no
+		/// DOTNET_ROOT. Kept in sync with the resolution there.
+		/// </summary>
+		internal static string DefaultSdkRoot()
+		{
+			var envRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+			if (!string.IsNullOrEmpty(envRoot) && Directory.Exists(envRoot))
+				return envRoot;
+
+			return Util.IsWindows
+				? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet")
+				: Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet");
+		}
 		
 		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
 		{
@@ -72,28 +95,12 @@ namespace DotNetCheck.Solutions
 				throw new InvalidOperationException(result.GetOutput());
 		}
 
+		/// <summary>
+		/// Kept as the name this solution's callers and tests already use; the probe itself
+		/// lives in <see cref="Util.IsDirectoryWritable"/> so the elevation decision here and
+		/// the <see cref="RequiresElevation"/> answer reported to hosts can never diverge.
+		/// </summary>
 		internal static bool IsDirectoryWritableOrCreatable(string path)
-		{
-			var candidate = path;
-			while (!string.IsNullOrEmpty(candidate) && !Directory.Exists(candidate))
-				candidate = Path.GetDirectoryName(candidate);
-
-			if (string.IsNullOrEmpty(candidate))
-				return false;
-
-			var probe = Path.Combine(candidate, $".uno-check-write-{Guid.NewGuid():N}");
-			try
-			{
-				using (File.Create(probe))
-				{
-				}
-				File.Delete(probe);
-				return true;
-			}
-			catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-			{
-				return false;
-			}
-		}
+			=> Util.IsDirectoryWritable(path);
 	}
 }

--- a/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
+++ b/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
@@ -23,6 +23,14 @@ namespace DotNetCheck.Solutions
 			_dotnetExePath = dotnetExePath;
 		}
 
+		/// <summary>
+		/// Workload manifests are written under the .NET root that owns this muxer, so the
+		/// answer follows that root's writability: a machine-wide SDK needs elevation, a
+		/// user-local one does not.
+		/// </summary>
+		public override bool RequiresElevation
+			=> !Util.IsDirectoryWritable(System.IO.Path.GetDirectoryName(_dotnetExePath) ?? _dotnetExePath);
+
 		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
 		{
 			await base.Implement(sharedState, cancellationToken);

--- a/UnoCheck/Solutions/LinuxGitSolution.cs
+++ b/UnoCheck/Solutions/LinuxGitSolution.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 using DotNetCheck.Models;
@@ -9,9 +9,14 @@ namespace DotNetCheck.Solutions
 	{
 		public override async Task Implement(SharedState state, CancellationToken ct)
 		{
-			await Util.WrapShellCommandWithSudo("apt", workingDir: null, verbose: true, new[] { "update" });
-
-			await Util.WrapShellCommandWithSudo("apt", workingDir: null, verbose: true, new[] { "install", "git" });
+			// One elevated invocation for the whole fix: update && install as a single
+			// shell chain, so the graphical authorization flow (pkexec) shows one dialog
+			// instead of one per apt command.
+			await Util.WrapShellCommandWithSudo(
+				"/bin/sh",
+				workingDir: null,
+				verbose: true,
+				new[] { "-c", "apt-get update && apt-get install -y git" });
 		}
 	}
 }

--- a/UnoCheck/Solutions/LinuxNinjaOpenUrlSolution.cs
+++ b/UnoCheck/Solutions/LinuxNinjaOpenUrlSolution.cs
@@ -7,6 +7,9 @@ namespace DotNetCheck.Solutions
 {
 	public class LinuxNinjaOpenUrlSolution : Solution
 	{
+		/// <summary>Only opens a web page in the user's session; elevating would break it.</summary>
+		public override bool RequiresElevation => false;
+
 		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
 		{
 			await base.Implement(sharedState, cancellationToken);

--- a/UnoCheck/Solutions/LinuxNinjaSolution.cs
+++ b/UnoCheck/Solutions/LinuxNinjaSolution.cs
@@ -1,4 +1,4 @@
-﻿using DotNetCheck.Models;
+using DotNetCheck.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,8 +10,12 @@ namespace DotNetCheck.Solutions
 		{
 			await base.Implement(sharedState, cancellationToken);
 
-			_ = await Util.WrapShellCommandWithSudo("apt-get", new[] { "update" });
-			_ = await Util.WrapShellCommandWithSudo("apt-get", new[] { "install", "ninja-build" });
+			// One elevated invocation for the whole fix: update && install as a single
+			// shell chain, so the graphical authorization flow (pkexec) shows one dialog
+			// instead of one per apt command.
+			_ = await Util.WrapShellCommandWithSudo(
+				"/bin/sh",
+				new[] { "-c", "apt-get update && apt-get install -y ninja-build" });
 
 			ReportStatus("Ninja Build System was installed on Linux.");
 		}

--- a/UnoCheck/Solutions/LinuxOtherDistGitCliSolution.cs
+++ b/UnoCheck/Solutions/LinuxOtherDistGitCliSolution.cs
@@ -1,4 +1,4 @@
-﻿using DotNetCheck.Models;
+using DotNetCheck.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,7 +10,15 @@ namespace DotNetCheck.Solutions
 		{
 			await base.Implement(sharedState, cancellationToken);
 
-			var r = await Util.WrapShellCommandWithSudo("x-www-browser", new[] { GitOpenUrl });
+			// Opening a browser needs the user's session, not root: elevation wrappers
+			// (sudo/pkexec) strip DISPLAY/WAYLAND_DISPLAY, so an elevated launch fails
+			// after authentication and the prompt only confuses.
+			var r = await Util.ShellCommand(
+				"x-www-browser",
+				workingDir: null,
+				verbose: Util.Verbose,
+				cancellationToken,
+				new[] { GitOpenUrl });
 
 			if (r.ExitCode == 0)
 			{

--- a/UnoCheck/Solutions/PSExecutionPolicySolution.cs
+++ b/UnoCheck/Solutions/PSExecutionPolicySolution.cs
@@ -7,6 +7,9 @@ namespace DotNetCheck.Solutions
 {
 	internal class PSExecutionPolicySolution : Solution
 	{
+		/// <summary>Sets the policy for <c>-Scope CurrentUser</c> only — never the machine scope.</summary>
+		public override bool RequiresElevation => false;
+
 		public override Task Implement(SharedState state, CancellationToken ct)
 		{
 			ShellProcessRunner.Run("powershell", "-Command Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned");

--- a/UnoCheck/Solutions/UnoSdkSolution.cs
+++ b/UnoCheck/Solutions/UnoSdkSolution.cs
@@ -18,6 +18,12 @@ namespace DotNetCheck.Solutions
 {
 	internal class UnoSdkSolution : Solution
 	{
+		/// <summary>
+		/// Restores the Uno.Sdk package through a scratch project in the temp directory and
+		/// the per-user NuGet cache — no machine location is written.
+		/// </summary>
+		public override bool RequiresElevation => false;
+
 		public override async Task Implement(SharedState state, CancellationToken ct)
 		{
 			var resource =

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -231,6 +231,35 @@ namespace DotNetCheck
 			return false;
 		}
 
+		/// <summary>
+		/// Whether the current user can create files under <paramref name="path"/> — probed by
+		/// actually creating one, since ACLs, redirection and read-only mounts all make an
+		/// attribute check unreliable. Used to decide <see cref="Models.Solution.RequiresElevation"/>
+		/// for solutions whose target location depends on the machine layout (a user-local
+		/// .NET root needs no elevation; the same install under Program Files does).
+		/// Walks up to the nearest existing ancestor so a not-yet-created target still answers.
+		/// </summary>
+		public static bool IsDirectoryWritable(string path)
+		{
+			var candidate = path;
+			while (!string.IsNullOrEmpty(candidate) && !Directory.Exists(candidate))
+				candidate = Path.GetDirectoryName(candidate);
+
+			if (string.IsNullOrEmpty(candidate))
+				return false;
+
+			try
+			{
+				var probe = Path.Combine(candidate, $".uno-check-write-{Guid.NewGuid():N}");
+				using (File.Create(probe, 1, FileOptions.DeleteOnClose)) { }
+				return true;
+			}
+			catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+			{
+				return false;
+			}
+		}
+
 		public static Task<ShellProcessRunner.ShellProcessResult> ShellCommand(string cmd, string workingDir, bool verbose, string[] args)
 			=> ShellCommand(cmd, workingDir, verbose, System.Threading.CancellationToken.None, args);
 

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -744,7 +744,15 @@ namespace DotNetCheck
 					RedirectOutput = Verbose
 				});
 
-				p.WaitForExit();
+				var sudoResult = p.WaitForExit();
+
+				// The authorization-dialog paths above throw on failure; this one used to
+				// discard the result, so a refused or failed sudo copy still reported the
+				// fix as applied. Fail the same way instead of silently doing nothing.
+				if (!sudoResult.Success)
+					throw new InvalidOperationException(
+						$"Elevated copy to '{destination}' failed with exit code {sudoResult.ExitCode}."
+						+ (Verbose ? $" Output:{Environment.NewLine}{sudoResult.GetOutput()}" : string.Empty));
 			}
 
 			return r;

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -186,6 +186,8 @@ Emits machine-readable JSONL on stdout — one JSON event per line (`run_started
 
 Intended for host applications, CI pipelines, and AI agents that embed uno-check. The event schema is documented in the repository under `specs/003-structured-json-output`.
 
+A failing check that can be repaired carries a `fix` object: `auto_fixable` says the fix can be run, `args` is the argument vector to run it with, and `requires_elevation` says whether running it needs administrator/root rights — so a host only elevates the fixes that actually need it (installing workloads into a machine-wide SDK, enabling Hyper-V, the long-path registry key) and leaves user-scoped ones (templates, the Uno SDK restore, a user-local SDK, Android SDK packages) unelevated. It is conservative: anything not known to be user-scoped reports `true`.
+
 ```bash
 uno-check --json --target wasm > results.jsonl
 ```

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -178,6 +178,7 @@ uno-check --fix --only androidsdk --non-interactive
 
 > [!NOTE]
 > With `--fix --non-interactive`, only the checkups named by `--only` are auto-fixed. Dependency checkups pulled into the run are examined for context but never fixed — a fix (and any elevation it needs) always corresponds to the checkup the caller requested. Interactive runs still confirm each fix individually.
+> Consequently, a host fixing several items in one child must name every selected id (`--only a --only b …`) instead of relying on a dependency to pull the rest in — which also keeps authorization prompts to exactly the items the user selected. A full-run `--fix` without `--only` still fixes everything it examines.
 
 ### `--json` Structured JSONL output
 

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -99,12 +99,32 @@ Stream guarantees:
 | `checkup_catalog` | emitted by `list --json` only: `schema_version`, `checkups[]` of `{ id, name, type_name }` (`name` is the display title, as in `checkup_result`; `type_name` is the checkup class name, which `--skip` also accepts) — the applicable-checkup menu for hosts building selection UIs that feed `--only`/`--skip` |
 
 **HealthCheck:** `id`, `name`, `status` (`ok`/`warning`/`error`/`skipped`), optional `message`,
-optional `skip_reason`, optional `fix` = `{ issue_id, description, auto_fixable, args }`.
+optional `skip_reason`, optional `fix` =
+`{ issue_id, description, auto_fixable, requires_elevation, args }`.
 `args` is the argument vector for the per-item fix (`["--fix", "--only", "<id>",
 "--non-interactive"]`), to be passed straight to the uno-check process — deliberately never a
 pre-joined command string, so no host is tempted to run it through a shell (checkup ids can
 embed manifest-sourced version text). Ids that fail the `[A-Za-z0-9._-]+` allowlist are never
 marked auto-fixable.
+
+`requires_elevation` answers *"will running `args` need administrator/root rights?"* — the
+question a host must settle **before** launching, because Windows elevates whole processes,
+not commands: without the signal the only safe choice is to elevate every fix, so
+user-scoped fixes (Android SDK packages, `dotnet new` templates, the Uno SDK restore,
+workloads into a user-writable SDK) raise UAC for nothing.
+
+- True when **any** solution behind the suggestion needs elevation — a fix applies them all,
+  so the host must satisfy the strictest one.
+- Conservative by construction: a solution requires elevation unless it is known to write
+  only user-scoped state. Layout-dependent solutions probe the real target instead of
+  assuming — the same workloads fix reports `false` against a user-local `DOTNET_ROOT` and
+  `true` against a Program Files SDK.
+- Advice-only suggestions (no runnable solution) report `false`; they also report
+  `auto_fixable: false`, so there is nothing to launch.
+- It describes the *fix*, not the current process: it stays meaningful when the host is
+  already elevated, and on macOS/Linux — where `--allow-elevation-prompt` elevates
+  per-command rather than per-process — it is what a host uses to warn that a dialog is
+  coming.
 
 **Report (final):** `schema_version`, `correlation_id`, `timestamp`, `tool_version`,
 `status` (`healthy`/`degraded`/`unhealthy`), optional `reason` (abnormal ends), `checks[]`,
@@ -138,10 +158,12 @@ checks failed.
    pins a released tool version, wrong for local dev builds.)
 2. Render per-check cards live from `checkup_*` events; summary from `report`.
 3. Fix one item:
-   - On Windows, launch elevated `uno-check --fix --only <id> --non-interactive
+   - On Windows, launch `uno-check --fix --only <id> --non-interactive
      --json-file <fresh-path> --correlation-id <this run's id>` using `fix.args` from the
-     check's result; tail the file for `fix_*` events and the fix child's own re-examined
-     `checkup_result`.
+     check's result, elevating the child (`runas`) **only when that check's
+     `fix.requires_elevation` is true**; tail the file for `fix_*` events and the fix
+     child's own re-examined `checkup_result`. The file transport is needed either way,
+     since an elevated child's stdout cannot be redirected.
    - On macOS, keep the same current-user JSON process and add `--allow-elevation-prompt`.
      User-level solutions run without a prompt. A solution that needs a protected location
      displays the system administrator dialog and elevates only its underlying command.
@@ -167,6 +189,9 @@ checks failed.
      Worth recording the observed value when next on a macOS host.
    - **A cached terminal `sudo` ticket is deliberately not reused**: authorization belongs to
      the fix the user clicked, so the dialog appears even right after a terminal `sudo`.
+   - **`fix.requires_elevation` is the pre-launch signal**, and it is what keeps user-scoped
+     fixes prompt-free: on Windows it decides `runas` before the child starts, and on
+     macOS/Linux a host can use it to warn that a dialog is coming.
 
 Host requirements:
 

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -150,15 +150,40 @@ checks failed.
      Declining the dialog — or a missing `pkexec` — surfaces as a failed `fix_result`.
    The terminal `report` marks the end of any child stream.
 
+   Authorization-dialog expectations for hosts:
+
+   - **Each protected command is its own authorization.** A single fix can prompt more than
+     once — e.g. a root-owned SDK's workloads fix runs repair and install through separate
+     elevated commands, so two dialogs. A "fix all" flow prompts the sum across items.
+     Solutions coalesce where they can (the apt-based fixes chain update+install into one
+     elevated shell), but hosts should not promise one dialog per fix.
+   - **The elevated command runs as root, not the user.** Per-user state the command touches
+     (NuGet caches, first-run sentinels) therefore lands by `HOME`: on Linux `pkexec` sets a
+     root `HOME` and scrubs the environment (the workload path re-injects what it needs via
+     `env`; on-host runs show root-owned artifacts under the system dotnet root). On macOS
+     the equivalent `HOME` under `do shell script … with administrator privileges` has not
+     been captured yet — either outcome is benign: root's home means a cold cache (slower),
+     the user's home means root-owned cache entries, same as the previous macOS `sudo` path.
+     Worth recording the observed value when next on a macOS host.
+   - **A cached terminal `sudo` ticket is deliberately not reused**: authorization belongs to
+     the fix the user clicked, so the dialog appears even right after a terminal `sudo`.
+
 Host requirements:
 
 - Drain stderr as well as stdout, or leave stderr unredirected: in `--json` mode the whole
   human-readable UI moves there, and an undrained pipe stalls the run once its buffer fills.
 - Treat process exit as an end-of-stream signal alongside `report`: an argument-parse failure
   produces no events and, on Windows, happens after the child's console has been hidden.
-- `fix.args` for an item scopes the run to that item **plus its required dependencies**, and
-  `--fix` applies to every checkup in the run — fixing the emulator can install the Android
-  SDK and JDK first. Surface that in the UI rather than promising a single-item change.
+- `fix.args` for an item scopes the run to that item **plus its required dependencies**, but
+  with `--only` present, `--fix --non-interactive` applies fixes **only to caller-named ids**
+  — dependencies are examined for context, never fixed. Two host-facing consequences:
+  - An item whose prerequisite is itself broken can resolve as `skipped` (dependency failure)
+    instead of fixed — the card goes from "Fix" to "skipped" with no visible progress unless
+    the host explains that the prerequisite must be fixed first.
+  - A "fix all" (or multi-item) flow must name **every** selected id (`--only a --only b …`)
+    rather than relying on dependency pull-in — which also keeps authorization prompts to
+    exactly the items the user selected. A full-run `--fix` without `--only` still fixes
+    everything it examines.
 
 ## Consumers
 

--- a/specs/004-reducing-elevation-prompts/spec.md
+++ b/specs/004-reducing-elevation-prompts/spec.md
@@ -1,0 +1,214 @@
+# Reducing elevation prompts
+
+Status: proposed — phased; Phase 0 is a prerequisite for the rest
+
+## Problem
+
+Fixing a fresh Windows machine through `uno-check --fix` can raise up to **eight** separate
+UAC prompts, because Windows elevates whole processes rather than individual commands: a host
+(or the CLI) must decide before launching, and each fix that touches a protected location is
+its own elevated launch.
+
+`fix.requires_elevation` (spec 003) told hosts *which* fixes need it, which stopped the
+needless prompts. It did not reduce the number of fixes that genuinely need elevation. This
+spec is about that second half.
+
+The distribution matters more than the count. Of the eight fixes that really need
+administrator rights today, **three write only the .NET root** — and those three are the only
+ones a developer hits *repeatedly*, on every SDK or workload bump:
+
+| Fix | Writes | Recurring? |
+|---|---|---|
+| `dotnet` (SDK install) | `%ProgramFiles%\dotnet` + HKLM bundle registration | on every pinned-SDK bump |
+| `dotnetworkloads-<v>` | `<SdkRoot>\{packs,sdk-manifests,metadata}` | on every workload bump |
+| `dotnettargetingpacks` | same subtrees, via `dotnet workload update` | on drift |
+| `openjdk` | `%ProgramFiles%\Microsoft\jdk-*` (MSI) | once per machine |
+| `androidsdk` | `%ProgramFiles(x86)%\Android\android-sdk` | once per machine (location-dependent) |
+| `windowslongpath` | `HKLM\SYSTEM\...\FileSystem\LongPathsEnabled` | once per machine |
+| `windowshyperv` | `dism /Online /Enable-Feature` | once per machine |
+| `git` | launches the VS Installer (self-elevating) | once per machine |
+
+So the goal is not "zero prompts ever" — enabling Hyper-V or a long-path registry key is a
+machine configuration change and will always require consent. The goal is that **the everyday
+path costs nothing, and the one-time machine setup costs one prompt, once.**
+
+## Goals
+
+1. **Zero prompts on the recurring path**: SDK, workloads, targeting packs, templates, Uno SDK,
+   Android SDK/emulator, dev-certs, PowerShell policy.
+2. **At most one prompt for one-time machine configuration**, and only when the user explicitly
+   asks for those fixes.
+3. **Never report healthy for a toolchain the user's IDE or CLI does not actually use.** This
+   is the hard invariant; everything below is subordinate to it.
+
+## Non-goals
+
+- **Taking a dependency on `dotnetup`.** The equivalent capability is already in-tree:
+  `Solutions/DotNetSdkScriptInstallSolution.cs` runs `dotnet-install` with an explicit
+  `-InstallDir`, and `DotNetSdk` already treats `DOTNET_ROOT` as the highest-precedence input.
+  Adding a preview-quality external toolchain manager would buy nothing we cannot do directly,
+  and would add a moving dependency to a tool people run on fresh machines. Revisit only if
+  `dotnetup` becomes the platform default for SDK acquisition.
+- **Making a managed root the single source of truth.** A host that also *drives the builds*
+  can do this safely. uno-check validates a toolchain other tools use, so a private root it
+  alone believes in is precisely how it would start reporting green on a broken machine.
+- **Automating the Visual Studio Installer.** `vswinworkloads` stays advice-only.
+
+## Current state
+
+Relevant facts established by inspection (file references are to `dev/vs/json-output`):
+
+- **The root is already a single choke point.** `DotNet/DotNetSdk.cs:59-85` resolves in order:
+  `DOTNET_ROOT` from shared state (seeded by `--dotnet <SDK_ROOT>` or the ambient variable at
+  `CheckCommand.cs:171-178`) → the vendored `EnvironmentProvider` (PATH) → well-known folders.
+  The result is written back to shared state and injected into every child process.
+- **Two of the three .NET prompts are already conditional.** `DotNetWorkloadsCheckup.cs:311-313`
+  and `Solutions/DotNetWorkloadUpdateSolution.cs:26-32` compute elevation as
+  `!Util.IsDirectoryWritable(<root>)`. Point the root somewhere user-writable and they stop
+  prompting **with no further code change**.
+- **The third is one branch.** `Checkups/DotNetCheckup.cs:99-113` routes interactive Windows to
+  `MsInstallerSolution` (the machine-wide `.exe`, unconditionally elevated) and only uses the
+  in-tree script installer under `Util.CI || Util.IsLinux`.
+- **The divergence risk is already known.** `Checkups/DotNetRootsCheckup.cs:64-71` exists to
+  warn when the effective root and the PATH root differ (issue #542). Any user-local design
+  makes that checkup load-bearing rather than advisory.
+
+## Design
+
+### Invariant
+
+> uno-check validates the root the machine actually resolves. It may *choose* a user-local root
+> only if it also *persists* that choice, so the IDE and the terminal resolve the same one.
+
+A user-local root that uno-check knows about and nothing else does is a worse outcome than a
+UAC prompt.
+
+### Phase 0 — correctness prerequisites (blocking)
+
+These are bugs today; they become false-green generators the moment a non-default root is in
+play. Phase 1 must not ship without them.
+
+| # | Item | Why it blocks |
+|---|---|---|
+| P0.1 | Route the four bare-`dotnet` call sites through the resolved muxer: `Checkups/DotNetNewUnoTemplatesCheckup.cs:70` (raw `ProcessStartInfo` — does not even inherit the injected `DOTNET_ROOT`), `Solutions/DotNetNewTemplatesInstallSolution.cs:43,49,53`, `Solutions/UnoSdkSolution.cs:60`, `Checkups/HttpsDevCertCheckup.cs:31,50` | With a user root that is not first on `PATH`, these silently examine and modify a different SDK than the one being validated. This is the false-green scenario, concretely. |
+| P0.2 | `DotNetSdk.cs:50-54` probes `$HOME/share/dotnet`; the real convention is `$HOME/.dotnet` | A user-local install is invisible to well-known-folder resolution. |
+| P0.3 | Align arch-variable precedence: `DotNetSdk` reads only `DOTNET_ROOT`, while `DotNetRootsCheckup.cs:81-94` and `DotNetTargetingPackAlignmentCheckup.cs:109-116` prefer `DOTNET_ROOT_<ARCH>` | A root designated only by the arch variable produces an internally inconsistent run: some checkups examine root A while workloads install into root B. |
+| P0.4 | `Checkups/WindowsLongPathCheckup.cs:20` opens HKLM **writable** merely to read | Unelevated it fails before it can report state, surfacing as "Requested registry access is not allowed" with no fix offered. Read-only probe, write only in the solution. |
+| P0.5 | `Solutions/PythonIsInstalledSolution.cs:19-24` only opens a Store URL, but inherits `RequiresElevation => true` | A prompt for nothing — and elevating a browser launch tends to break it. Mirror `LinuxNinjaOpenUrlSolution`. |
+| P0.6 | Remove dead solutions: `CreateFileSolution` (zero references), `LinuxOtherDistGitCliSolution` (zero references) | Both would misreport elevation if revived. |
+
+### Phase 1 — user-local .NET root as a first-class scope
+
+**P1.1 — an explicit scope switch.** New option `--dotnet-install-scope <auto|user|machine>`
+(default `auto`). Surfaced in the structured contract so hosts can offer it.
+
+**P1.2 — let Windows use the script installer.** Widen the `Util.CI || Util.IsLinux` gate at
+`DotNetCheckup.cs:99` so that under `user` scope every platform uses
+`DotNetSdkScriptInstallSolution`. Its elevation answer is already probe-based
+(`DotNetSdkScriptInstallSolution.cs:31`), so it reports correctly for whichever root it targets.
+
+**P1.3 — a user root default.** `DotNetSdkScriptInstallSolution.DefaultSdkRoot()` returns
+Program Files on Windows (`:43-45`). Under `user` scope it must return the per-user location
+(`%USERPROFILE%\.dotnet`, matching `dotnet-install`'s own default).
+
+**P1.4 — persist the choice.** This is the part that makes it safe, and the part MAUI.Sherpa
+sidesteps by owning the builds it validates. When uno-check installs into a user-local root it
+must set, at **user** scope (never machine):
+- `DOTNET_ROOT`
+- `PATH` entry for that root, ordered ahead of the machine install
+
+`Checkups/OpenJdkCheckup.cs:99-106` already does the equivalent for `JAVA_HOME`, and is the
+precedent to follow — except at `EnvironmentVariableTarget.User`, which itself needs no
+elevation. Add a checkup that verifies the persisted variables still point at the root
+uno-check manages, so drift is reported rather than silently tolerated.
+
+**P1.5 — the `auto` policy.** Choose `user` when *all* hold:
+- no writable machine-wide SDK is already in use, **and**
+- no Visual Studio installation is detected (`VisualStudioWindowsCheckup.GetWindowsInfo()`),
+  since VS resolves its own SDK and a user root would diverge from what VS builds with
+
+Otherwise `machine`. Rationale: the developers who benefit most (Rider, VS Code, CLI, CI) get
+the prompt-free path; VS users keep the toolchain VS actually uses. `--dotnet-install-scope`
+lets either group override.
+
+**P1.6 — promote `DotNetRootsCheckup`.** Once a user root is a supported mode, a divergence
+between the effective root and the PATH root stops being informational. Report it as an error
+when uno-check itself created the user root, with a fix that repairs the persisted variables.
+
+### Phase 2 — the remaining one-time prompts
+
+**P2.1 — OpenJDK without an MSI.** Microsoft OpenJDK ships a `.zip`/`.tar.gz` alongside the
+installer. Extracting to a per-user location and setting `JAVA_HOME` at user scope removes a
+prompt. Requires a manifest addition (archive URLs beside the existing `urls`) and changes
+`OpenJdkCheckup.cs:99-106` from a machine-scope `JAVA_HOME` write to a user-scope one.
+
+**P2.2 — Android SDK per-user default.** `androidsdk` is already probe-based; it prompts only
+because the Windows default is `%ProgramFiles(x86)%\Android\android-sdk`. When no
+`ANDROID_HOME` exists, prefer a per-user location and persist it the same way as P1.4.
+
+**P2.3 — one prompt for genuine machine settings.** `windowslongpath` and `windowshyperv`
+cannot avoid elevation. They can share one. The `--only` contract already supports naming
+several ids in one child (spec 003, host flow), so a host — or `--fix` itself — can apply all
+selected machine-scoped fixes in a **single** elevated invocation:
+`--fix --only windowslongpath --only windowshyperv`. To make that groupable without hosts
+hardcoding a list, add an `elevation_scope` discriminator to `FixInfo`
+(`"none" | "user" | "machine"`), so a host can partition the selected fixes into "run
+unelevated now" and "one elevated batch".
+
+**P2.4 — `git` stays as-is.** It launches the VS Installer, which self-elevates; there is
+nothing for uno-check to improve.
+
+### Phase 3 — host-side contract
+
+- `requires_elevation` (shipped) decides whether a child is elevated.
+- `elevation_scope` (P2.3) lets a host batch machine-scoped fixes into one approval and mark
+  the affected rows with a shield before the user clicks.
+- Hosts should surface the chosen install scope, since it changes what "your environment"
+  means. A host that installs into a user root must say so.
+
+### Phase 4 — verification
+
+Each phase lands with unit coverage for the pure decisions (scope selection, root resolution,
+elevation classification) plus a manual matrix, because the failure modes are environmental:
+
+| Environment | What must be true |
+|---|---|
+| Windows + Visual Studio | `auto` picks `machine`; behaviour unchanged from today |
+| Windows, no VS, no SDK | `auto` picks `user`; a full fix run completes with **zero** prompts except an explicitly requested machine-settings batch |
+| Windows, existing machine SDK | `auto` picks `machine`; no silent switch |
+| macOS | script installer into `~/.dotnet`; authorization dialog only for protected commands |
+| Linux | unchanged (already user-local by default); polkit only for protected commands |
+| After any user-root install | a fresh terminal **and** the IDE resolve the same root uno-check validated |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| **False green** — uno-check validates a root nothing else uses | The invariant, P0.1 (no bare `dotnet`), P1.4 (persistence), P1.6 (divergence becomes an error) |
+| **Two SDK worlds** on one machine (disk, confusion, "why do I have two dotnets") | `auto` never switches a machine that already has a working machine-wide SDK; scope is reported in output and in the structured contract |
+| **VS users regressing** | `auto` selects `machine` whenever VS is detected |
+| **PATH ordering fights** with other installers | The persisted-variables checkup (P1.4) detects and repairs |
+| **Phase 1 landing without Phase 0** | Sequencing is explicit; Phase 0 items are individually shippable and worth landing regardless |
+
+## Alternatives considered
+
+- **Adopt `dotnetup`.** Rejected as a dependency (see Non-goals): the in-tree script installer
+  already provides the capability, and `dotnetup` is published at `daily` quality.
+- **Always install user-local.** Rejected: breaks VS users, and would make the divergence the
+  default state rather than an opt-in.
+- **Keep machine-wide and reduce prompts by batching only.** Insufficient: it leaves the
+  recurring SDK/workload path prompting on every version bump, which is the actual complaint.
+- **Self-elevate the whole tool once per run.** Rejected previously for hosts; it also
+  elevates work that does not need it, and the manifest question (spec 003 open question) is
+  unresolved.
+
+## Open questions
+
+1. On a fresh Windows machine **with** VS present but **no** SDK — does `auto` still defer to
+   `machine`? Proposed yes (VS will want the machine SDK), but it is the case where a user
+   would most appreciate zero prompts.
+2. Should uno-check write the user `PATH` entry, or only `DOTNET_ROOT` and tell the user? PATH
+   is what makes a plain terminal agree; it is also the more invasive edit.
+3. Is `elevation_scope` worth adding to the contract now, or should hosts infer "machine" from
+   `requires_elevation` until a second consumer needs the distinction?
+4. Ownership of the manifest change for OpenJDK archive URLs (P2.1).


### PR DESCRIPTION
## Summary

A phased plan to get the **everyday fix path to zero elevation prompts** and the one-time machine setup to **a single prompt**, grounded in an inventory of every fixable checkup and what it actually writes.

Stacked on #551 because it builds on `fix.requires_elevation`. Spec only — no code changes.

## The finding that shapes the plan

Eight fixes genuinely need administrator rights on Windows. Only **three** write the .NET root — and those three are the only ones a developer hits *repeatedly*, on every SDK or workload bump. The other five (long paths, Hyper-V, JDK MSI, Git via the VS Installer, the Android SDK location) are once-per-machine.

Better still, the .NET side is closer to done than it looks:

- `DotNetWorkloadsCheckup` and `DotNetWorkloadUpdateSolution` already decide elevation as `!IsDirectoryWritable(root)` — they stop prompting the moment the root is user-writable, **with no code change**.
- The SDK install itself is one branch: `DotNetCheckup.cs:99` routes interactive Windows to the machine-wide `.exe` installer, while the in-tree `DotNetSdkScriptInstallSolution` (which takes an explicit `-InstallDir` and already probes elevation) is gated behind `Util.CI || Util.IsLinux`.
- `DotNetSdk` already treats `DOTNET_ROOT` as the highest-precedence input and propagates it to every child.

## What the plan deliberately does *not* do

- **No external user-level toolchain manager dependency.** The capability is already in-tree; adding a `daily`-quality dependency to a tool people run on fresh machines buys nothing we cannot do directly.
- **No "managed root is the single source of truth".** A tool that also drives the builds can do that safely. uno-check validates a toolchain *other* tools use, so a private root it alone believes in is exactly how it would start reporting healthy for a broken machine. `DotNetRootsCheckup` already exists to warn about that divergence (#542).

## Phases

- **Phase 0 (blocking)** — correctness gaps that become false-green generators under a non-default root. Notably four call sites that shell out to bare `dotnet` instead of the resolved muxer (one of them via raw `ProcessStartInfo`, so it does not even inherit the injected `DOTNET_ROOT`), the Linux well-known probe looking for `~/share/dotnet` instead of `~/.dotnet`, and an arch-variable precedence mismatch. These are worth landing regardless of the rest.
- **Phase 1** — user-local .NET root as a first-class scope: `--dotnet-install-scope auto|user|machine`, the Windows script-installer path, a per-user default root, **persistence of the choice** (user-scope `DOTNET_ROOT`/`PATH`, the part that keeps the IDE and terminal in agreement), and an `auto` policy that defers to `machine` whenever Visual Studio is present.
- **Phase 2** — the remaining one-time prompts: a per-user OpenJDK archive install, a per-user Android SDK default, and batching the genuine machine settings (long paths + Hyper-V) into **one** elevated invocation via an `elevation_scope` discriminator on `FixInfo`.
- **Phase 3/4** — host contract and a verification matrix (the failure modes here are environmental, so the matrix matters as much as the unit tests).

## Two side findings worth fixing regardless

- `windowspyhtonInstallation` reports `requires_elevation: true`, but its fix only opens a Store URL in a browser — a prompt for nothing, and elevating it would likely break the launch.
- `WindowsLongPathCheckup` opens HKLM **writable** just to read it, so unelevated it fails before it can report state ("Requested registry access is not allowed") instead of offering its fix.

Open questions are listed at the end of the spec — the main one is whether `auto` should still defer to `machine` on a fresh Windows box that has VS but no SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)