### PR TITLE
feat: ship a client for the structured output contract

### DIFF
--- a/UnoCheck.Tests/DotNetSdkScriptInstallSolutionTests.cs
+++ b/UnoCheck.Tests/DotNetSdkScriptInstallSolutionTests.cs
@@ -1,0 +1,29 @@
+using DotNetCheck.Solutions;
+
+namespace UnoCheck.Tests;
+
+public class DotNetSdkScriptInstallSolutionTests
+{
+    [Fact]
+    public void IsDirectoryWritableOrCreatable_UsesNearestExistingParent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "uno-check-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var nestedPath = Path.Combine(tempDir, "not-created", "dotnet");
+
+            Assert.True(DotNetSdkScriptInstallSolution.IsDirectoryWritableOrCreatable(nestedPath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsDirectoryWritableOrCreatable_MissingPath_ReturnsFalse()
+    {
+        Assert.False(DotNetSdkScriptInstallSolution.IsDirectoryWritableOrCreatable(string.Empty));
+    }
+}

--- a/UnoCheck.Tests/DotNetWorkloadFeedbackTests.cs
+++ b/UnoCheck.Tests/DotNetWorkloadFeedbackTests.cs
@@ -57,6 +57,21 @@ public class DotNetWorkloadFeedbackTests
     }
 
     [Fact]
+    public void BuildInstallArgs_PreservesPathsAndSourcesAsSeparateArguments()
+    {
+        var args = DotNetWorkloadManager.BuildInstallArgs(
+            sdkVersion: "10.0.103",
+            rollbackFile: "/Users/Test User/workload.json",
+            workloadIds: ["wasm-tools"],
+            packageSources: ["/Users/Test User/local feed"],
+            verbose: false);
+
+        Assert.Equal(
+            ["workload", "install", "--from-rollback-file", "/Users/Test User/workload.json", "wasm-tools", "--source", "/Users/Test User/local feed"],
+            args);
+    }
+
+    [Fact]
     public void BuildRepairArgs_AddsDetailedVerbosityWhenVerboseEnabled()
     {
         var args = DotNetWorkloadManager.BuildRepairArgs(

--- a/UnoCheck.Tests/JsonStructuredOutputTests.cs
+++ b/UnoCheck.Tests/JsonStructuredOutputTests.cs
@@ -118,6 +118,77 @@ public class BuildHealthCheckTests
 
         Assert.Null(CheckCommand.BuildHealthCheck(checkup, diagnosis).Fix);
     }
+
+    [Fact]
+    public void Error_Without_Message_Falls_Back_To_Suggestion_Description()
+    {
+        // Some checkups (e.g. a workloads mismatch) report status without a message;
+        // hosts would render a bare card with no explanation.
+        var checkup = new FakeCheckup("dotnetworkloads-10.0.201");
+        var diagnosis = new DiagnosticResult(
+            Status.Error, checkup,
+            new Suggestion("Install .NET workloads", "Installing .NET workloads.", new NoopSolution()));
+
+        var check = CheckCommand.BuildHealthCheck(checkup, diagnosis);
+
+        Assert.Equal("Installing .NET workloads.", check.Message);
+    }
+
+    [Fact]
+    public void Error_Without_Message_Or_Description_Falls_Back_To_Suggestion_Name()
+    {
+        var checkup = new FakeCheckup("unosdk");
+        var diagnosis = new DiagnosticResult(Status.Error, checkup, new Suggestion("Install the SDK", new NoopSolution()));
+
+        var check = CheckCommand.BuildHealthCheck(checkup, diagnosis);
+
+        Assert.Equal("Install the SDK", check.Message);
+    }
+
+    [Fact]
+    public void Explicit_Message_Wins_Over_Suggestion_Fallback()
+    {
+        var checkup = new FakeCheckup("unosdk");
+        var diagnosis = new DiagnosticResult(
+            Status.Error, checkup, "Uno.Sdk 6.7.22 is not installed.",
+            new Suggestion("Install the SDK", new NoopSolution()));
+
+        var check = CheckCommand.BuildHealthCheck(checkup, diagnosis);
+
+        Assert.Equal("Uno.Sdk 6.7.22 is not installed.", check.Message);
+    }
+}
+
+public class IsCallerNamedForFixTests
+{
+    [Fact]
+    public void Without_Only_Every_Checkup_Qualifies()
+    {
+        Assert.True(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", null));
+        Assert.True(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", []));
+    }
+
+    [Fact]
+    public void Caller_Named_Id_Qualifies_Case_Insensitively()
+    {
+        Assert.True(CheckCommand.IsCallerNamedForFix("unosdk", ["UnoSdk"]));
+    }
+
+    [Fact]
+    public void Dependency_Included_Checkup_Is_Not_AutoFixed()
+    {
+        // --only unosdk pulls dotnet/workloads in as examine-only dependencies; fixing
+        // them would raise an elevation prompt for a command the user never requested.
+        Assert.False(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", ["unosdk"]));
+        Assert.False(CheckCommand.IsCallerNamedForFix("dotnet", ["unosdk"]));
+    }
+
+    [Fact]
+    public void Prefix_Does_Not_Qualify_A_Caller_Name()
+    {
+        // Caller ids match exactly — the one-way prefix rule is for dependency ids only.
+        Assert.False(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", ["dotnetworkloads"]));
+    }
 }
 
 public class SafeCheckupIdTests

--- a/UnoCheck.Tests/JsonStructuredOutputTests.cs
+++ b/UnoCheck.Tests/JsonStructuredOutputTests.cs
@@ -34,6 +34,22 @@ file class NoopSolution : Solution
 {
 }
 
+/// <summary>Solution with a caller-chosen elevation answer (or one that throws while deciding).</summary>
+file class ElevationSolution : Solution
+{
+    private readonly bool _requiresElevation;
+    private readonly bool _throws;
+
+    public ElevationSolution(bool requiresElevation, bool throws = false)
+    {
+        _requiresElevation = requiresElevation;
+        _throws = throws;
+    }
+
+    public override bool RequiresElevation
+        => _throws ? throw new UnauthorizedAccessException("probe failed") : _requiresElevation;
+}
+
 public class BuildHealthCheckTests
 {
     [Fact]
@@ -120,6 +136,28 @@ public class BuildHealthCheckTests
     }
 
     [Fact]
+    public void Unclassified_Solution_Requires_Elevation()
+    {
+        // The base default is conservative: a needless prompt beats a fix that fails
+        // halfway through because the host did not elevate.
+        var checkup = new FakeCheckup("hyperv");
+        var diagnosis = new DiagnosticResult(Status.Error, checkup, new Suggestion("Enable it", new NoopSolution()));
+
+        Assert.True(CheckCommand.BuildHealthCheck(checkup, diagnosis).Fix!.RequiresElevation);
+    }
+
+    [Fact]
+    public void User_Scoped_Solution_Does_Not_Require_Elevation()
+    {
+        // The point of the field: a host must not raise UAC for a fix that only writes
+        // per-user state (templates, the Uno SDK restore, a user-local SDK).
+        var checkup = new FakeCheckup("dotnetnewunotemplates");
+        var diagnosis = new DiagnosticResult(Status.Error, checkup, new Suggestion("Install", new ElevationSolution(false)));
+
+        Assert.False(CheckCommand.BuildHealthCheck(checkup, diagnosis).Fix!.RequiresElevation);
+    }
+
+    [Fact]
     public void Error_Without_Message_Falls_Back_To_Suggestion_Description()
     {
         // Some checkups (e.g. a workloads mismatch) report status without a message;
@@ -188,6 +226,67 @@ public class IsCallerNamedForFixTests
     {
         // Caller ids match exactly — the one-way prefix rule is for dependency ids only.
         Assert.False(CheckCommand.IsCallerNamedForFix("dotnetworkloads-10.0.201", ["dotnetworkloads"]));
+    }
+}
+
+public class RequiresElevationTests
+{
+    [Fact]
+    public void Any_Elevated_Solution_Makes_The_Whole_Fix_Elevated()
+    {
+        // A fix applies every solution behind the suggestion, so the host has to satisfy
+        // the strictest one — reporting false here would fail the fix midway.
+        var suggestion = new Suggestion("Mixed", new ElevationSolution(false), new ElevationSolution(true));
+
+        Assert.True(CheckCommand.RequiresElevation(suggestion));
+    }
+
+    [Fact]
+    public void All_User_Scoped_Solutions_Need_No_Elevation()
+    {
+        var suggestion = new Suggestion("User scoped", new ElevationSolution(false), new ElevationSolution(false));
+
+        Assert.False(CheckCommand.RequiresElevation(suggestion));
+    }
+
+    [Fact]
+    public void Suggestion_Without_Solutions_Needs_No_Elevation()
+    {
+        // Nothing to run, so nothing to elevate: an advice-only suggestion must not make a
+        // host prompt for a fix it cannot apply.
+        Assert.False(CheckCommand.RequiresElevation(new Suggestion("Manual steps only")));
+    }
+
+    [Fact]
+    public void A_Failing_Probe_Falls_Back_To_Requiring_Elevation()
+    {
+        // Deciding can touch the filesystem (SDK root writability); if that throws, the
+        // safe answer is the conservative one rather than an unelevated fix that fails.
+        var suggestion = new Suggestion("Probe throws", new ElevationSolution(false, throws: true));
+
+        Assert.True(CheckCommand.RequiresElevation(suggestion));
+    }
+
+    [Fact]
+    public void Known_User_Scoped_Solutions_Report_No_Elevation()
+    {
+        // These are the fixes a host was previously forced to elevate for no reason:
+        // per-user template store, per-user NuGet/temp restore, CurrentUser policy scope.
+        Assert.False(new DotNetCheck.Solutions.DotNetNewTemplatesInstallSolution(false, false).RequiresElevation);
+        Assert.False(new DotNetCheck.Solutions.UnoSdkSolution().RequiresElevation);
+        Assert.False(new DotNetCheck.Solutions.PSExecutionPolicySolution().RequiresElevation);
+        Assert.False(new DotNetCheck.Solutions.LinuxNinjaOpenUrlSolution().RequiresElevation);
+    }
+
+    [Fact]
+    public void Layout_Dependent_Solutions_Follow_The_Targets_Writability()
+    {
+        // The same workloads fix is elevated against a machine-wide SDK and unelevated
+        // against a user-local one, so the answer must come from the target, not the type.
+        var userLocal = new DotNetCheck.Solutions.DotNetWorkloadUpdateSolution(
+            Path.Combine(Path.GetTempPath(), "dotnet", "dotnet"));
+
+        Assert.False(userLocal.RequiresElevation);
     }
 }
 

--- a/UnoCheck.Tests/LinuxAdministratorCommandRunnerTests.cs
+++ b/UnoCheck.Tests/LinuxAdministratorCommandRunnerTests.cs
@@ -1,0 +1,75 @@
+using DotNetCheck;
+
+namespace UnoCheck.Tests;
+
+public class LinuxAdministratorCommandRunnerTests
+{
+    [Fact]
+    public void BuildArguments_PreservesArgumentBoundariesVerbatim()
+    {
+        var arguments = LinuxAdministratorCommandRunner.BuildArguments(
+            "/home/test user/.dotnet/dotnet",
+            ["workload", "install", "value with spaces", "$(touch /tmp/bad)", "it's-safe"]);
+
+        Assert.Equal(
+            ["/home/test user/.dotnet/dotnet", "workload", "install", "value with spaces", "$(touch /tmp/bad)", "it's-safe"],
+            arguments);
+    }
+
+    [Fact]
+    public void BuildArguments_RequiresAnExecutable()
+    {
+        Assert.Throws<ArgumentException>(() => LinuxAdministratorCommandRunner.BuildArguments(" ", []));
+    }
+
+    [Theory]
+    [InlineData(true, false, true, true, true)]
+    [InlineData(true, false, true, false, false)]
+    [InlineData(true, true, true, true, false)]
+    [InlineData(true, false, false, true, false)]
+    [InlineData(false, false, true, true, false)]
+    public void ShouldUseLinuxAdministratorPrompt_RequiresLinuxStructuredHostOutsideCi(
+        bool isLinux,
+        bool ci,
+        bool structuredOutput,
+        bool allowElevationPrompt,
+        bool expected)
+    {
+        Assert.Equal(expected, Util.ShouldUseLinuxAdministratorPrompt(isLinux, ci, structuredOutput, allowElevationPrompt));
+    }
+
+    [Fact]
+    public void WasDeclined_RecognizesDismissedExitCode()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], [], 126);
+
+        Assert.True(LinuxAdministratorCommandRunner.WasDeclined(result));
+    }
+
+    [Fact]
+    public void WasDeclined_RecognizesDismissedMessage()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult(
+            [],
+            ["Error executing command as another user: Request dismissed"],
+            127);
+
+        Assert.True(LinuxAdministratorCommandRunner.WasDeclined(result));
+    }
+
+    [Fact]
+    public void WasDeclined_DoesNotHideOtherFailures()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], ["dotnet workload install failed"], 1);
+
+        Assert.False(LinuxAdministratorCommandRunner.WasDeclined(result));
+    }
+
+    [Fact]
+    public void WasDeclined_IgnoresSuccessfulRuns()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], [], 0);
+
+        Assert.False(LinuxAdministratorCommandRunner.WasDeclined(result));
+    }
+}

--- a/UnoCheck.Tests/MacOsAdministratorCommandRunnerTests.cs
+++ b/UnoCheck.Tests/MacOsAdministratorCommandRunnerTests.cs
@@ -1,0 +1,52 @@
+using DotNetCheck;
+
+namespace UnoCheck.Tests;
+
+public class MacOsAdministratorCommandRunnerTests
+{
+    [Fact]
+    public void BuildCommandLine_QuotesExecutableAndEveryArgument()
+    {
+        var command = MacOsAdministratorCommandRunner.BuildCommandLine(
+            "/Users/Test User/.dotnet/dotnet",
+            ["workload", "install", "value with spaces", "$(touch /tmp/bad)", "it's-safe"]);
+
+        Assert.Equal(
+            "'/Users/Test User/.dotnet/dotnet' 'workload' 'install' 'value with spaces' '$(touch /tmp/bad)' 'it'\"'\"'s-safe'",
+            command);
+    }
+
+    [Theory]
+    [InlineData(true, false, true, true, true)]
+    [InlineData(true, false, true, false, false)]
+    [InlineData(true, true, true, true, false)]
+    [InlineData(true, false, false, true, false)]
+    [InlineData(false, false, true, true, false)]
+    public void ShouldUseMacOsAdministratorPrompt_RequiresMacStructuredHostOutsideCi(
+        bool isMac,
+        bool ci,
+        bool structuredOutput,
+        bool allowElevationPrompt,
+        bool expected)
+    {
+        Assert.Equal(expected, Util.ShouldUseMacOsAdministratorPrompt(isMac, ci, structuredOutput, allowElevationPrompt));
+    }
+
+    [Theory]
+    [InlineData("execution error: User canceled. (-128)")]
+    [InlineData("Execution error: User cancelled. (-128)")]
+    public void WasDeclined_RecognizesMacOsAuthorizationCancellation(string error)
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], [error], 1);
+
+        Assert.True(MacOsAdministratorCommandRunner.WasDeclined(result));
+    }
+
+    [Fact]
+    public void WasDeclined_DoesNotHideOtherFailures()
+    {
+        var result = new ShellProcessRunner.ShellProcessResult([], ["xcodebuild failed"], 1);
+
+        Assert.False(MacOsAdministratorCommandRunner.WasDeclined(result));
+    }
+}

--- a/UnoCheck.Tests/ShellProcessRunnerTests.cs
+++ b/UnoCheck.Tests/ShellProcessRunnerTests.cs
@@ -6,6 +6,25 @@ namespace UnoCheck.Tests;
 public class ShellProcessRunnerTests
 {
 	[Fact]
+	public void WaitForExit_ArgumentList_PreservesArgumentBoundaries()
+	{
+		if (OperatingSystem.IsWindows())
+			return;
+
+		var sut = new ShellProcessRunner(new ShellProcessRunnerOptions("/bin/sh", string.Empty)
+		{
+			ArgumentList = ["-c", "printf '%s' \"$1\"", "sh", "value with spaces; $(echo unsafe)"],
+			UseSystemShell = false,
+			RedirectOutput = true,
+		});
+
+		var result = sut.WaitForExit();
+
+		Assert.True(result.Success);
+		Assert.Equal("value with spaces; $(echo unsafe)", string.Join(Environment.NewLine, result.StandardOutput));
+	}
+
+	[Fact]
 	public void WaitForExit_CapturesStdOutAndStdErr_AndReturnsExitCode()
 	{
 		var (executable, args) = GetShellCommand(

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -59,6 +59,7 @@ namespace DotNetCheck.Cli
 			Util.Verbose = settings.Verbose;
 			Util.LogFile = settings.LogFile;
 			Util.CI = settings.CI;
+			Util.AllowElevationPrompt = settings.AllowElevationPrompt;
 			if (settings.CI)
 				settings.NonInteractive = true;
 
@@ -394,8 +395,11 @@ namespace DotNetCheck.Cli
 					// needs to have a remedy available to even bother asking/trying
 					var doFix = diagnosis.Suggestion.HasSolution
 						&& (
-							// --fix + --non-interactive == auto fix, no prompt
-							(settings.NonInteractive && settings.Fix)
+							// --fix + --non-interactive == auto fix, no prompt — but only for
+							// checkups the caller named with --only: dependencies are examined
+							// for context, never auto-fixed. A host-side elevation prompt must
+							// describe the fix the user actually requested, not a dependency's.
+							(settings.NonInteractive && settings.Fix && IsCallerNamedForFix(checkup.Id, settings.Only))
 							// interactive (default) + prompt/confirm they want to fix
 							|| (!settings.NonInteractive && AnsiConsole.Confirm($"[bold]{Icon.Bell} Attempt to fix?[/]"))
 						);
@@ -638,6 +642,17 @@ namespace DotNetCheck.Cli
 		private string _activeFixCheckupId;
 
 		/// <summary>
+		/// Whether a checkup was named by the caller (exact, case-insensitive) and may be
+		/// auto-fixed in a non-interactive --fix --only run. Without --only every checkup
+		/// qualifies; with --only, dependency-included checkups are examined but not fixed.
+		/// </summary>
+#nullable enable
+		internal static bool IsCallerNamedForFix(string checkupId, string[]? only)
+			=> only is not { Length: > 0 }
+				|| only.Any(o => string.Equals(o, checkupId, StringComparison.OrdinalIgnoreCase));
+#nullable restore
+
+		/// <summary>
 		/// --only: scope the run to the requested checkup(s) plus their required dependencies.
 		/// Caller-supplied ids match exactly (case-insensitive) so a per-item fix can never
 		/// select siblings the caller did not name. Ids declared by dependencies keep the
@@ -714,12 +729,23 @@ namespace DotNetCheck.Cli
 				};
 			}
 
+			// Some checkups report a non-Ok status with no message (e.g. a workloads mismatch),
+			// which renders as a bare card in hosts. Fall back to the suggestion text so the
+			// JSON always carries a human-readable reason for a failed check.
+			var message = diagnosis.Message;
+			if (string.IsNullOrEmpty(message) && diagnosis.Status != Models.Status.Ok && diagnosis.HasSuggestion)
+			{
+				message = string.IsNullOrEmpty(diagnosis.Suggestion.Description)
+					? diagnosis.Suggestion.Name
+					: diagnosis.Suggestion.Description;
+			}
+
 			return new Json.HealthCheck
 			{
 				Id = checkup.Id,
 				Name = checkup.Title,
 				Status = Json.JsonlOutput.StatusName(diagnosis.Status),
-				Message = diagnosis.Message,
+				Message = message,
 				Fix = fix,
 			};
 		}

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -395,8 +395,11 @@ namespace DotNetCheck.Cli
 					// needs to have a remedy available to even bother asking/trying
 					var doFix = diagnosis.Suggestion.HasSolution
 						&& (
-							// --fix + --non-interactive == auto fix, no prompt
-							(settings.NonInteractive && settings.Fix)
+							// --fix + --non-interactive == auto fix, no prompt — but only for
+							// checkups the caller named with --only: dependencies are examined
+							// for context, never auto-fixed. A host-side elevation prompt must
+							// describe the fix the user actually requested, not a dependency's.
+							(settings.NonInteractive && settings.Fix && IsCallerNamedForFix(checkup.Id, settings.Only))
 							// interactive (default) + prompt/confirm they want to fix
 							|| (!settings.NonInteractive && AnsiConsole.Confirm($"[bold]{Icon.Bell} Attempt to fix?[/]"))
 						);
@@ -639,6 +642,17 @@ namespace DotNetCheck.Cli
 		private string _activeFixCheckupId;
 
 		/// <summary>
+		/// Whether a checkup was named by the caller (exact, case-insensitive) and may be
+		/// auto-fixed in a non-interactive --fix --only run. Without --only every checkup
+		/// qualifies; with --only, dependency-included checkups are examined but not fixed.
+		/// </summary>
+#nullable enable
+		internal static bool IsCallerNamedForFix(string checkupId, string[]? only)
+			=> only is not { Length: > 0 }
+				|| only.Any(o => string.Equals(o, checkupId, StringComparison.OrdinalIgnoreCase));
+#nullable restore
+
+		/// <summary>
 		/// --only: scope the run to the requested checkup(s) plus their required dependencies.
 		/// Caller-supplied ids match exactly (case-insensitive) so a per-item fix can never
 		/// select siblings the caller did not name. Ids declared by dependencies keep the
@@ -715,12 +729,23 @@ namespace DotNetCheck.Cli
 				};
 			}
 
+			// Some checkups report a non-Ok status with no message (e.g. a workloads mismatch),
+			// which renders as a bare card in hosts. Fall back to the suggestion text so the
+			// JSON always carries a human-readable reason for a failed check.
+			var message = diagnosis.Message;
+			if (string.IsNullOrEmpty(message) && diagnosis.Status != Models.Status.Ok && diagnosis.HasSuggestion)
+			{
+				message = string.IsNullOrEmpty(diagnosis.Suggestion.Description)
+					? diagnosis.Suggestion.Name
+					: diagnosis.Suggestion.Description;
+			}
+
 			return new Json.HealthCheck
 			{
 				Id = checkup.Id,
 				Name = checkup.Title,
 				Status = Json.JsonlOutput.StatusName(diagnosis.Status),
-				Message = diagnosis.Message,
+				Message = message,
 				Fix = fix,
 			};
 		}

--- a/UnoCheck/CheckCommand.cs
+++ b/UnoCheck/CheckCommand.cs
@@ -723,6 +723,7 @@ namespace DotNetCheck.Cli
 						? diagnosis.Suggestion.Name
 						: $"{diagnosis.Suggestion.Name}: {diagnosis.Suggestion.Description}",
 					AutoFixable = fixable,
+					RequiresElevation = RequiresElevation(diagnosis.Suggestion),
 					Args = fixable
 						? new[] { "--fix", "--only", checkup.Id, "--non-interactive" }
 						: null,
@@ -748,6 +749,36 @@ namespace DotNetCheck.Cli
 				Message = message,
 				Fix = fix,
 			};
+		}
+
+		/// <summary>
+		/// A suggestion needs elevation when any of its solutions does — a fix applies them
+		/// all, so the host must elevate for the strictest one. A suggestion with no
+		/// solutions cannot be fixed at all, and reports false rather than an idle prompt.
+		/// Evaluating each solution may probe the filesystem (writability of an SDK root),
+		/// so a solution that throws is treated as elevation-requiring: the conservative
+		/// answer, matching the base default.
+		/// </summary>
+		internal static bool RequiresElevation(Suggestion suggestion)
+		{
+			if (suggestion?.Solutions is not { } solutions)
+				return false;
+
+			foreach (var solution in solutions)
+			{
+				try
+				{
+					if (solution.RequiresElevation)
+						return true;
+				}
+				catch (Exception ex)
+				{
+					Util.Exception(ex);
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		private void CheckupStatusUpdated(object sender, CheckupStatusEventArgs e)

--- a/UnoCheck/CheckSettings.Uno.cs
+++ b/UnoCheck/CheckSettings.Uno.cs
@@ -54,7 +54,7 @@ Targets: webassembly ios android macos linux windows"
 
         [CommandOption("--allow-elevation-prompt")]
         [Description(
-            @"Allow a structured macOS fix run to display the system administrator authorization dialog. Ignored in CI.")]
+            @"Allow a structured macOS or Linux fix run to display the system authorization dialog (macOS administrator prompt / Linux polkit). Ignored in CI.")]
         public bool AllowElevationPrompt { get; set; }
 	}
 }

--- a/UnoCheck/CheckSettings.Uno.cs
+++ b/UnoCheck/CheckSettings.Uno.cs
@@ -51,5 +51,10 @@ Targets: webassembly ios android macos linux windows"
         [Description(
             @"Correlation id stamped on structured-output events. Hosts pass their own id when launching a child process (e.g. an elevated fix) so both processes report as one logical run. Defaults to a new id per run.")]
         public string? CorrelationId { get; set; }
+
+        [CommandOption("--allow-elevation-prompt")]
+        [Description(
+            @"Allow a structured macOS or Linux fix run to display the system authorization dialog (macOS administrator prompt / Linux polkit). Ignored in CI.")]
+        public bool AllowElevationPrompt { get; set; }
 	}
 }

--- a/UnoCheck/Checkups/AndroidEmulatorCheckup.cs
+++ b/UnoCheck/Checkups/AndroidEmulatorCheckup.cs
@@ -174,7 +174,9 @@ namespace DotNetCheck.Checkups
 							}
 
 							return Task.CompletedTask;
-						})).ToArray())));
+						},
+						// Creating an AVD writes the per-user Android home (~/.android).
+						requiresElevation: false)).ToArray())));
 		}
 	}
 

--- a/UnoCheck/Checkups/AndroidSdkCheckup.cs
+++ b/UnoCheck/Checkups/AndroidSdkCheckup.cs
@@ -255,7 +255,10 @@ For more information see: [underline]https://aka.ms/dotnet-androidsdk-help[/]";
 								}
 							}
 						}
-					}))));
+					},
+					// Packages install into the discovered Android SDK: the usual per-user
+					// location needs no elevation, a shared/Program Files one does.
+					requiresElevation: !Util.IsDirectoryWritable(sdkInstance.Path)))));
 
 		}
 

--- a/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
+++ b/UnoCheck/Checkups/DotNetWorkloadsCheckup.cs
@@ -307,7 +307,10 @@ namespace DotNetCheck.Checkups
 					}
 
 					history.ContributeState(StateKey.EntryPoint, StateKey.ShouldRestartVs, true);
-				})));
+				},
+				// Workloads install into this SDK root: a machine-wide SDK needs elevation,
+				// a user-local one (DOTNET_ROOT, ~/.dotnet) does not.
+				requiresElevation: !Util.IsDirectoryWritable(SdkRoot))));
 		}
 	}
 }

--- a/UnoCheck/Checkups/HttpsDevCertCheckup.cs
+++ b/UnoCheck/Checkups/HttpsDevCertCheckup.cs
@@ -51,7 +51,11 @@ namespace DotNetCheck.Checkups
                         Directory.GetCurrentDirectory(),
                         Util.Verbose,
                         ["dev-certs", "https", "--trust"]);
-                })
+                },
+                // Windows/macOS trust the cert in the user's own store — the OS may still
+                // show its own trust confirmation, which is not elevation. Linux writes the
+                // system trust store and does need root.
+                requiresElevation: Util.IsLinux)
             );
 
             return new DiagnosticResult(Status.Error, this, suggestion);

--- a/UnoCheck/Checkups/XCodeCheckup.cs
+++ b/UnoCheck/Checkups/XCodeCheckup.cs
@@ -135,10 +135,16 @@ namespace DotNetCheck.Checkups
 						Status.Error,
 						this,
 						new Suggestion("Run xcode-select -s <Path>",
-							new Solutions.ActionSolution((sln, cancelToken) =>
+							new Solutions.ActionSolution(async (sln, cancelToken) =>
 							{
-								ShellProcessRunner.Run("xcode-select", "-s " + eligibleXcode.Path);
-								return Task.CompletedTask;
+								var result = await Util.WrapShellCommandWithSudo(
+									"/usr/bin/xcode-select",
+									workingDir: null,
+									verbose: Util.Verbose,
+									cancellationToken: cancelToken,
+									args: new[] { "-s", eligibleXcode.Path });
+								if (!result.Success)
+									throw new InvalidOperationException(result.GetOutput());
 							}))));
 				}
 

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -82,19 +82,16 @@ namespace DotNetCheck.DotNet
 		/// <see cref="WorkloadCliEnv"/> re-set inside the elevated child. Required for sudo paths
 		/// because sudo's default <c>env_reset</c> strips any var we set on the parent process.
 		///
-		/// Two variants exist because the consumers tokenize the args differently and the dotnet
-		/// path has to be quoted for the right consumer. Use this one for callers that hand the
-		/// args off to <see cref="Util.WrapShellCommandWithSudoNoPrompt"/>: that helper interpolates
-		/// the args into a <c>sh -c '…'</c> block, so <paramref name="dotnetExe"/> is shell-double-
-		/// quoted to survive the inner shell's re-interpretation of <c>$</c>/backtick/<c>\</c>/<c>"</c>
-		/// and to keep paths with spaces as one token.
+		/// Two variants exist because the interactive sudo consumer still accepts a rendered
+		/// argument string. Shell and graphical consumers accept a typed argument list and
+		/// apply their own escaping.
 		/// </summary>
 		static string[] BuildEnglishCliSudoArgsForShell(string dotnetExe, string[] args)
 		{
 			var result = new List<string>(args.Length + WorkloadCliEnv.Count + 1);
 			foreach (var kv in WorkloadCliEnv)
 				result.Add($"{kv.Key}={kv.Value}");
-			result.Add(Util.ShellDoubleQuote(dotnetExe));
+			result.Add(dotnetExe);
 			result.AddRange(args);
 			return result.ToArray();
 		}
@@ -115,7 +112,7 @@ namespace DotNetCheck.DotNet
 			foreach (var kv in WorkloadCliEnv)
 				result.Add($"{kv.Key}={kv.Value}");
 			result.Add(Util.QuoteForProcessArgs(dotnetExe));
-			result.AddRange(args);
+			result.AddRange(args.Select(Util.QuoteForProcessArgs));
 			return result.ToArray();
 		}
 
@@ -174,10 +171,14 @@ namespace DotNetCheck.DotNet
 				"workload",
 				"install",
 				"--from-rollback-file",
-				$"\"{rollbackFile}\""
+				rollbackFile
 			};
 			args.AddRange(workloadIds);
-			args.AddRange(packageSources.Select(ps => $"{addSourceArg} \"{ps}\""));
+			foreach (var packageSource in packageSources)
+			{
+				args.Add(addSourceArg);
+				args.Add(packageSource);
+			}
 
 			if (verbose)
 			{
@@ -199,7 +200,11 @@ namespace DotNetCheck.DotNet
 				"workload",
 				"repair"
 			};
-			args.AddRange(packageSources.Select(ps => $"{addSourceArg} \"{ps}\""));
+			foreach (var packageSource in packageSources)
+			{
+				args.Add(addSourceArg);
+				args.Add(packageSource);
+			}
 
 			if (verbose)
 			{
@@ -497,6 +502,21 @@ namespace DotNetCheck.DotNet
 		/// </summary>
 		async Task<ShellProcessRunner.ShellProcessResult> RetryWithSudo(string dotnetExe, CancellationToken cancellationToken, string[] args)
 		{
+			// Structured macOS/Linux hosts opt into the system authorization dialog. Do not
+			// use an unrelated terminal sudo ticket: authorization belongs to this fix request.
+			// Deliberate trade: a user who just authenticated in a terminal still gets the
+			// dialog, and each protected command is its own authorization — a workload
+			// repair + install can prompt twice for one fix (recorded in spec 003's host flow).
+			if (Util.UseAdministratorPrompt)
+			{
+				return await Util.WrapShellCommandWithSudo(
+					"env",
+					DotNetCliWorkingDir,
+					Util.Verbose,
+					cancellationToken,
+					BuildEnglishCliSudoArgsForShell(dotnetExe, args));
+			}
+
 			// Always try non-interactive sudo first (works with cached credentials or NOPASSWD).
 			// Invoke through `env` so DOTNET_CLI_UI_LANGUAGE survives sudo's default env_reset —
 			// see WorkloadCliEnv for the full rationale. The two sudo helpers tokenize args

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -504,6 +504,9 @@ namespace DotNetCheck.DotNet
 		{
 			// Structured macOS/Linux hosts opt into the system authorization dialog. Do not
 			// use an unrelated terminal sudo ticket: authorization belongs to this fix request.
+			// Deliberate trade: a user who just authenticated in a terminal still gets the
+			// dialog, and each protected command is its own authorization — a workload
+			// repair + install can prompt twice for one fix (recorded in spec 003's host flow).
 			if (Util.UseAdministratorPrompt)
 			{
 				return await Util.WrapShellCommandWithSudo(

--- a/UnoCheck/DotNet/DotNetWorkloadManager.cs
+++ b/UnoCheck/DotNet/DotNetWorkloadManager.cs
@@ -502,9 +502,12 @@ namespace DotNetCheck.DotNet
 		/// </summary>
 		async Task<ShellProcessRunner.ShellProcessResult> RetryWithSudo(string dotnetExe, CancellationToken cancellationToken, string[] args)
 		{
-			// Structured macOS hosts opt into the system authorization dialog. Do not use
-			// an unrelated Terminal sudo ticket: authorization belongs to this fix request.
-			if (Util.UseMacOsAdministratorPrompt)
+			// Structured macOS/Linux hosts opt into the system authorization dialog. Do not
+			// use an unrelated terminal sudo ticket: authorization belongs to this fix request.
+			// Deliberate trade: a user who just authenticated in a terminal still gets the
+			// dialog, and each protected command is its own authorization — a workload
+			// repair + install can prompt twice for one fix (recorded in spec 003's host flow).
+			if (Util.UseAdministratorPrompt)
 			{
 				return await Util.WrapShellCommandWithSudo(
 					"env",

--- a/UnoCheck/Json/JsonOutput.cs
+++ b/UnoCheck/Json/JsonOutput.cs
@@ -403,6 +403,18 @@ namespace DotNetCheck.Json
 		public bool AutoFixable { get; init; }
 
 		/// <summary>
+		/// Whether applying the fix needs administrator/root rights. Windows has no
+		/// per-command elevation, so a host must decide before launching whether to use the
+		/// <c>runas</c> verb; without this signal the only safe choice is to elevate every
+		/// fix. True when any solution behind the suggestion needs it, and conservative by
+		/// construction: a solution requires elevation unless it is known to write only
+		/// user-scoped state, and layout-dependent ones (the .NET SDK root, the Android SDK)
+		/// probe the actual target's writability rather than assuming.
+		/// </summary>
+		[JsonPropertyName("requires_elevation")]
+		public bool RequiresElevation { get; init; }
+
+		/// <summary>
 		/// Argument vector for a per-item fix, to be passed straight to the uno-check
 		/// process with no shell involved. Never a pre-joined command string: checkup
 		/// ids can embed manifest-sourced version text, and a joined string invites

--- a/UnoCheck/Models/Solution.cs
+++ b/UnoCheck/Models/Solution.cs
@@ -12,6 +12,20 @@ namespace DotNetCheck.Models
 		public virtual Task Implement(SharedState sharedState, System.Threading.CancellationToken cancellationToken)
 			=> Task.CompletedTask;
 
+		/// <summary>
+		/// Whether applying this solution needs administrator/root rights. Surfaced to
+		/// structured hosts as <c>fix.requires_elevation</c> so a host can decide, before
+		/// launching, whether the fix child needs elevation — Windows has no per-command
+		/// elevation, so without this signal a host must elevate every fix.
+		///
+		/// Defaults to <see langword="true"/>: an unclassified solution keeps today's
+		/// conservative behavior (a needless prompt is an annoyance; a missing one is a
+		/// failed fix). Solutions that only ever write user-scoped state override it to
+		/// <see langword="false"/>, and solutions whose target depends on the machine layout
+		/// compute it from that target's writability.
+		/// </summary>
+		public virtual bool RequiresElevation => true;
+
 		public void ReportStatus(string message)
 			=> OnStatusUpdated?.Invoke(this, new RemedyStatusEventArgs(this, message));
 

--- a/UnoCheck/Process/LinuxAdministratorCommandRunner.cs
+++ b/UnoCheck/Process/LinuxAdministratorCommandRunner.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace DotNetCheck
+{
+	/// <summary>
+	/// Runs one command through the Linux polkit authorization dialog (pkexec).
+	/// The containing Uno.Check process remains in the original user's context.
+	/// pkexec receives the program and its arguments as a typed argument vector —
+	/// no shell is involved, so argument boundaries are preserved as-is.
+	/// </summary>
+	internal static class LinuxAdministratorCommandRunner
+	{
+		static readonly string[] PkexecPaths = { "/usr/bin/pkexec", "/bin/pkexec" };
+
+		public static ShellProcessRunner.ShellProcessResult Run(
+			string executable,
+			string workingDirectory,
+			bool verbose,
+			CancellationToken cancellationToken,
+			IReadOnlyList<string> arguments)
+		{
+			if (!Util.IsLinux)
+				throw new PlatformNotSupportedException("The polkit authorization dialog is only available on Linux.");
+
+			var pkexec = PkexecPaths.FirstOrDefault(File.Exists)
+				?? throw new FileNotFoundException(
+					"The polkit authorization tool (pkexec) was not found. Install the polkit package for your distribution.",
+					PkexecPaths[0]);
+
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var runner = new ShellProcessRunner(new ShellProcessRunnerOptions(pkexec, string.Empty, cancellationToken)
+			{
+				ArgumentList = BuildArguments(executable, arguments),
+				WorkingDirectory = workingDirectory,
+				Verbose = verbose,
+				UseSystemShell = false,
+				RedirectOutput = true,
+			});
+
+			var result = runner.WaitForExit();
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (WasDeclined(result))
+			{
+				return new ShellProcessRunner.ShellProcessResult(
+					result.StandardOutput,
+					new List<string> { "Administrator approval was declined." },
+					result.ExitCode);
+			}
+
+			return result;
+		}
+
+		internal static IReadOnlyList<string> BuildArguments(string executable, IEnumerable<string> arguments)
+		{
+			if (string.IsNullOrWhiteSpace(executable))
+				throw new ArgumentException("An executable is required.", nameof(executable));
+
+			var argumentList = new List<string> { executable };
+			argumentList.AddRange(arguments ?? Array.Empty<string>());
+			return argumentList;
+		}
+
+		/// <summary>
+		/// pkexec exits with 126 when the user dismisses the authentication dialog and
+		/// writes "Request dismissed" to stderr; 127 covers authorization failures.
+		/// Only the explicit dismissal is normalized — other failures keep their output.
+		/// </summary>
+		internal static bool WasDeclined(ShellProcessRunner.ShellProcessResult result)
+		{
+			if (result == null || result.Success)
+				return false;
+
+			if (result.ExitCode == 126)
+				return true;
+
+			var output = result.StandardOutput.Concat(result.StandardError);
+			return output.Any(line =>
+				line?.IndexOf("Request dismissed", StringComparison.OrdinalIgnoreCase) >= 0);
+		}
+	}
+}

--- a/UnoCheck/Process/MacOsAdministratorCommandRunner.cs
+++ b/UnoCheck/Process/MacOsAdministratorCommandRunner.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace DotNetCheck
+{
+	/// <summary>
+	/// Runs one command through the macOS system administrator authorization dialog.
+	/// The containing Uno.Check process remains in the original user's context.
+	/// </summary>
+	internal static class MacOsAdministratorCommandRunner
+	{
+		const string OsascriptPath = "/usr/bin/osascript";
+		const string RunHandler = "on run argv";
+		const string ElevatedCommand = "do shell script (item 1 of argv) with administrator privileges with prompt \"Uno.Check needs administrator access to apply this fix.\"";
+		const string EndHandler = "end run";
+
+		public static ShellProcessRunner.ShellProcessResult Run(
+			string executable,
+			string workingDirectory,
+			bool verbose,
+			CancellationToken cancellationToken,
+			IReadOnlyList<string> arguments)
+		{
+			if (!Util.IsMac)
+				throw new PlatformNotSupportedException("The macOS administrator dialog is only available on macOS.");
+
+			if (!File.Exists(OsascriptPath))
+				throw new FileNotFoundException("The macOS administrator authorization tool was not found.", OsascriptPath);
+
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var commandLine = BuildCommandLine(executable, arguments);
+			var runner = new ShellProcessRunner(new ShellProcessRunnerOptions(OsascriptPath, string.Empty, cancellationToken)
+			{
+				ArgumentList = new[] { "-e", RunHandler, "-e", ElevatedCommand, "-e", EndHandler, "--", commandLine },
+				WorkingDirectory = workingDirectory,
+				Verbose = verbose,
+				UseSystemShell = false,
+				RedirectOutput = true,
+			});
+
+			var result = runner.WaitForExit();
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (WasDeclined(result))
+			{
+				return new ShellProcessRunner.ShellProcessResult(
+					result.StandardOutput,
+					new List<string> { "Administrator approval was declined." },
+					result.ExitCode);
+			}
+
+			return result;
+		}
+
+		internal static string BuildCommandLine(string executable, IEnumerable<string> arguments)
+		{
+			if (string.IsNullOrWhiteSpace(executable))
+				throw new ArgumentException("An executable is required.", nameof(executable));
+
+			var command = new List<string> { PosixShellQuote(executable) };
+			command.AddRange((arguments ?? Array.Empty<string>()).Select(PosixShellQuote));
+			return string.Join(" ", command);
+		}
+
+		internal static string PosixShellQuote(string value)
+			=> "'" + (value ?? string.Empty).Replace("'", "'\"'\"'") + "'";
+
+		internal static bool WasDeclined(ShellProcessRunner.ShellProcessResult result)
+		{
+			if (result == null || result.Success)
+				return false;
+
+			var output = result.StandardOutput.Concat(result.StandardError);
+			return output.Any(line =>
+				line?.IndexOf("User canceled", StringComparison.OrdinalIgnoreCase) >= 0
+				|| line?.IndexOf("User cancelled", StringComparison.OrdinalIgnoreCase) >= 0
+				|| line?.IndexOf("(-128)", StringComparison.OrdinalIgnoreCase) >= 0);
+		}
+	}
+}

--- a/UnoCheck/Process/ShellProcessRunner.cs
+++ b/UnoCheck/Process/ShellProcessRunner.cs
@@ -26,6 +26,7 @@ namespace DotNetCheck
 		 
 		public string Executable { get; set; }
 		public string Args { get; set; }
+		public IReadOnlyList<string> ArgumentList { get; set; }
 
 		public bool Verbose { get;set; }
 
@@ -79,6 +80,9 @@ namespace DotNetCheck
 
 			if (Options.UseSystemShell)
 			{
+				if (Options.ArgumentList != null)
+					throw new ArgumentException("ArgumentList cannot be combined with UseSystemShell.", nameof(options));
+
 				string tmpFile = null;
 
 				if (!Util.IsWindows)
@@ -95,7 +99,15 @@ namespace DotNetCheck
 			else
 			{
 				process.StartInfo.FileName = Options.Executable;
-				process.StartInfo.Arguments = Options.Args;
+				if (Options.ArgumentList == null)
+				{
+					process.StartInfo.Arguments = Options.Args;
+				}
+				else
+				{
+					foreach (var argument in Options.ArgumentList)
+						process.StartInfo.ArgumentList.Add(argument);
+				}
 			}
 
 			process.StartInfo.UseShellExecute = false;

--- a/UnoCheck/Solutions/ActionSolution.cs
+++ b/UnoCheck/Solutions/ActionSolution.cs
@@ -7,12 +7,20 @@ namespace DotNetCheck.Solutions
 {
 	public class ActionSolution : Solution
 	{
-		public ActionSolution(Func<Solution, CancellationToken, Task> curer)
+		/// <param name="requiresElevation">
+		/// Whether the action needs administrator/root rights. Left at <see langword="true"/>
+		/// unless the call site knows the action only writes user-scoped state — see
+		/// <see cref="Solution.RequiresElevation"/>.
+		/// </param>
+		public ActionSolution(Func<Solution, CancellationToken, Task> curer, bool requiresElevation = true)
 		{
 			Curer = curer;
+			RequiresElevation = requiresElevation;
 		}
 
 		public Func<Solution, CancellationToken, Task> Curer { get; private set; }
+
+		public override bool RequiresElevation { get; }
 
 		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
 		{

--- a/UnoCheck/Solutions/DotNetNewTemplatesInstallSolution.cs
+++ b/UnoCheck/Solutions/DotNetNewTemplatesInstallSolution.cs
@@ -17,6 +17,12 @@ internal class DotNetNewTemplatesInstallSolution : Solution
     private readonly bool _uninstallExisting;
     private readonly NuGetVersion? _requestedVersion;
 
+    /// <summary>
+    /// <c>dotnet new install/uninstall</c> writes the per-user template engine store
+    /// (~/.templateengine), never a machine location.
+    /// </summary>
+    public override bool RequiresElevation => false;
+
     public DotNetNewTemplatesInstallSolution(
         bool uninstallLegacy, 
         bool uninstallExisting, 

--- a/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
+++ b/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
@@ -57,14 +57,43 @@ namespace DotNetCheck.Solutions
 			};
 
 			var args = Util.IsWindows
-					? $"\"{scriptPath}\" -InstallDir \"{sdkRoot}\" -Version \"{Version}\""
-					: $"\"{scriptPath}\" --install-dir \"{sdkRoot}\" --version \"{Version}\"";
+				? new[] { Util.QuoteForProcessArgs(scriptPath), "-InstallDir", Util.QuoteForProcessArgs(sdkRoot), "-Version", Version }
+				: new[] { scriptPath, "--install-dir", sdkRoot, "--version", Version };
 
 			Util.Log($"Executing dotnet-install script...");
-			Util.Log($"\t{exe} {args}");
+			Util.Log($"\t{exe} {string.Join(" ", args)}");
 
-			// Launch the process
-			await Util.WrapShellCommandWithSudo(exe, [args]);
+			// A user-local SDK install stays in the user's context. Only a protected
+			// DOTNET_ROOT is elevated, and then only the install command itself.
+			var result = !Util.IsWindows && IsDirectoryWritableOrCreatable(sdkRoot)
+				? await Util.ShellCommand(exe, workingDir: null, verbose: Util.Verbose, cancellationToken: cancellationToken, args: args)
+				: await Util.WrapShellCommandWithSudo(exe, workingDir: null, verbose: Util.Verbose, cancellationToken: cancellationToken, args: args);
+			if (!result.Success)
+				throw new InvalidOperationException(result.GetOutput());
+		}
+
+		internal static bool IsDirectoryWritableOrCreatable(string path)
+		{
+			var candidate = path;
+			while (!string.IsNullOrEmpty(candidate) && !Directory.Exists(candidate))
+				candidate = Path.GetDirectoryName(candidate);
+
+			if (string.IsNullOrEmpty(candidate))
+				return false;
+
+			var probe = Path.Combine(candidate, $".uno-check-write-{Guid.NewGuid():N}");
+			try
+			{
+				using (File.Create(probe))
+				{
+				}
+				File.Delete(probe);
+				return true;
+			}
+			catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+			{
+				return false;
+			}
 		}
 	}
 }

--- a/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
+++ b/UnoCheck/Solutions/DotNetSdkScriptInstallSolution.cs
@@ -21,6 +21,29 @@ namespace DotNetCheck.Solutions
 		}
 
 		public readonly string Version;
+
+		/// <summary>
+		/// Depends on the machine layout: the default Windows root is under Program Files
+		/// (elevation required), while a DOTNET_ROOT or the unix default of ~/.dotnet is
+		/// user-writable. Probed rather than assumed, so a user-local SDK does not make a
+		/// host prompt needlessly.
+		/// </summary>
+		public override bool RequiresElevation => !Util.IsDirectoryWritable(DefaultSdkRoot());
+
+		/// <summary>
+		/// The root <see cref="Implement"/> installs into when SharedState carries no
+		/// DOTNET_ROOT. Kept in sync with the resolution there.
+		/// </summary>
+		internal static string DefaultSdkRoot()
+		{
+			var envRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+			if (!string.IsNullOrEmpty(envRoot) && Directory.Exists(envRoot))
+				return envRoot;
+
+			return Util.IsWindows
+				? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet")
+				: Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet");
+		}
 		
 		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
 		{
@@ -72,28 +95,12 @@ namespace DotNetCheck.Solutions
 				throw new InvalidOperationException(result.GetOutput());
 		}
 
+		/// <summary>
+		/// Kept as the name this solution's callers and tests already use; the probe itself
+		/// lives in <see cref="Util.IsDirectoryWritable"/> so the elevation decision here and
+		/// the <see cref="RequiresElevation"/> answer reported to hosts can never diverge.
+		/// </summary>
 		internal static bool IsDirectoryWritableOrCreatable(string path)
-		{
-			var candidate = path;
-			while (!string.IsNullOrEmpty(candidate) && !Directory.Exists(candidate))
-				candidate = Path.GetDirectoryName(candidate);
-
-			if (string.IsNullOrEmpty(candidate))
-				return false;
-
-			var probe = Path.Combine(candidate, $".uno-check-write-{Guid.NewGuid():N}");
-			try
-			{
-				using (File.Create(probe))
-				{
-				}
-				File.Delete(probe);
-				return true;
-			}
-			catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-			{
-				return false;
-			}
-		}
+			=> Util.IsDirectoryWritable(path);
 	}
 }

--- a/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
+++ b/UnoCheck/Solutions/DotNetWorkloadUpdateSolution.cs
@@ -23,6 +23,14 @@ namespace DotNetCheck.Solutions
 			_dotnetExePath = dotnetExePath;
 		}
 
+		/// <summary>
+		/// Workload manifests are written under the .NET root that owns this muxer, so the
+		/// answer follows that root's writability: a machine-wide SDK needs elevation, a
+		/// user-local one does not.
+		/// </summary>
+		public override bool RequiresElevation
+			=> !Util.IsDirectoryWritable(System.IO.Path.GetDirectoryName(_dotnetExePath) ?? _dotnetExePath);
+
 		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
 		{
 			await base.Implement(sharedState, cancellationToken);

--- a/UnoCheck/Solutions/LinuxGitSolution.cs
+++ b/UnoCheck/Solutions/LinuxGitSolution.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 using DotNetCheck.Models;
@@ -9,9 +9,14 @@ namespace DotNetCheck.Solutions
 	{
 		public override async Task Implement(SharedState state, CancellationToken ct)
 		{
-			await Util.WrapShellCommandWithSudo("apt", workingDir: null, verbose: true, new[] { "update" });
-
-			await Util.WrapShellCommandWithSudo("apt", workingDir: null, verbose: true, new[] { "install", "git" });
+			// One elevated invocation for the whole fix: update && install as a single
+			// shell chain, so the graphical authorization flow (pkexec) shows one dialog
+			// instead of one per apt command.
+			await Util.WrapShellCommandWithSudo(
+				"/bin/sh",
+				workingDir: null,
+				verbose: true,
+				new[] { "-c", "apt-get update && apt-get install -y git" });
 		}
 	}
 }

--- a/UnoCheck/Solutions/LinuxNinjaOpenUrlSolution.cs
+++ b/UnoCheck/Solutions/LinuxNinjaOpenUrlSolution.cs
@@ -7,6 +7,9 @@ namespace DotNetCheck.Solutions
 {
 	public class LinuxNinjaOpenUrlSolution : Solution
 	{
+		/// <summary>Only opens a web page in the user's session; elevating would break it.</summary>
+		public override bool RequiresElevation => false;
+
 		public override async Task Implement(SharedState sharedState, CancellationToken cancellationToken)
 		{
 			await base.Implement(sharedState, cancellationToken);

--- a/UnoCheck/Solutions/LinuxNinjaSolution.cs
+++ b/UnoCheck/Solutions/LinuxNinjaSolution.cs
@@ -1,4 +1,4 @@
-﻿using DotNetCheck.Models;
+using DotNetCheck.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,8 +10,12 @@ namespace DotNetCheck.Solutions
 		{
 			await base.Implement(sharedState, cancellationToken);
 
-			_ = await Util.WrapShellCommandWithSudo("apt-get", new[] { "update" });
-			_ = await Util.WrapShellCommandWithSudo("apt-get", new[] { "install", "ninja-build" });
+			// One elevated invocation for the whole fix: update && install as a single
+			// shell chain, so the graphical authorization flow (pkexec) shows one dialog
+			// instead of one per apt command.
+			_ = await Util.WrapShellCommandWithSudo(
+				"/bin/sh",
+				new[] { "-c", "apt-get update && apt-get install -y ninja-build" });
 
 			ReportStatus("Ninja Build System was installed on Linux.");
 		}

--- a/UnoCheck/Solutions/LinuxOtherDistGitCliSolution.cs
+++ b/UnoCheck/Solutions/LinuxOtherDistGitCliSolution.cs
@@ -1,4 +1,4 @@
-﻿using DotNetCheck.Models;
+using DotNetCheck.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,7 +10,15 @@ namespace DotNetCheck.Solutions
 		{
 			await base.Implement(sharedState, cancellationToken);
 
-			var r = await Util.WrapShellCommandWithSudo("x-www-browser", new[] { GitOpenUrl });
+			// Opening a browser needs the user's session, not root: elevation wrappers
+			// (sudo/pkexec) strip DISPLAY/WAYLAND_DISPLAY, so an elevated launch fails
+			// after authentication and the prompt only confuses.
+			var r = await Util.ShellCommand(
+				"x-www-browser",
+				workingDir: null,
+				verbose: Util.Verbose,
+				cancellationToken,
+				new[] { GitOpenUrl });
 
 			if (r.ExitCode == 0)
 			{

--- a/UnoCheck/Solutions/PSExecutionPolicySolution.cs
+++ b/UnoCheck/Solutions/PSExecutionPolicySolution.cs
@@ -7,6 +7,9 @@ namespace DotNetCheck.Solutions
 {
 	internal class PSExecutionPolicySolution : Solution
 	{
+		/// <summary>Sets the policy for <c>-Scope CurrentUser</c> only — never the machine scope.</summary>
+		public override bool RequiresElevation => false;
+
 		public override Task Implement(SharedState state, CancellationToken ct)
 		{
 			ShellProcessRunner.Run("powershell", "-Command Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned");

--- a/UnoCheck/Solutions/UnoSdkSolution.cs
+++ b/UnoCheck/Solutions/UnoSdkSolution.cs
@@ -18,6 +18,12 @@ namespace DotNetCheck.Solutions
 {
 	internal class UnoSdkSolution : Solution
 	{
+		/// <summary>
+		/// Restores the Uno.Sdk package through a scratch project in the temp directory and
+		/// the per-user NuGet cache — no machine location is written.
+		/// </summary>
+		public override bool RequiresElevation => false;
+
 		public override async Task Implement(SharedState state, CancellationToken ct)
 		{
 			var resource =

--- a/UnoCheck/Solutions/XcodeEulaSolution.cs
+++ b/UnoCheck/Solutions/XcodeEulaSolution.cs
@@ -11,7 +11,9 @@ namespace DotNetCheck.Solutions
 		{
 			await base.Implement(sharedState, cancellationToken);
 
-			_ = await Util.WrapShellCommandWithSudo("xcodebuild", new[] { "-license", "accept" });
+			var result = await Util.WrapShellCommandWithSudo("/usr/bin/xcodebuild", new[] { "-license", "accept" });
+			if (!result.Success)
+				throw new InvalidOperationException(result.GetOutput());
 		}
 	}
 }

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -231,6 +231,35 @@ namespace DotNetCheck
 			return false;
 		}
 
+		/// <summary>
+		/// Whether the current user can create files under <paramref name="path"/> — probed by
+		/// actually creating one, since ACLs, redirection and read-only mounts all make an
+		/// attribute check unreliable. Used to decide <see cref="Models.Solution.RequiresElevation"/>
+		/// for solutions whose target location depends on the machine layout (a user-local
+		/// .NET root needs no elevation; the same install under Program Files does).
+		/// Walks up to the nearest existing ancestor so a not-yet-created target still answers.
+		/// </summary>
+		public static bool IsDirectoryWritable(string path)
+		{
+			var candidate = path;
+			while (!string.IsNullOrEmpty(candidate) && !Directory.Exists(candidate))
+				candidate = Path.GetDirectoryName(candidate);
+
+			if (string.IsNullOrEmpty(candidate))
+				return false;
+
+			try
+			{
+				var probe = Path.Combine(candidate, $".uno-check-write-{Guid.NewGuid():N}");
+				using (File.Create(probe, 1, FileOptions.DeleteOnClose)) { }
+				return true;
+			}
+			catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+			{
+				return false;
+			}
+		}
+
 		public static Task<ShellProcessRunner.ShellProcessResult> ShellCommand(string cmd, string workingDir, bool verbose, string[] args)
 			=> ShellCommand(cmd, workingDir, verbose, System.Threading.CancellationToken.None, args);
 

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -744,7 +744,15 @@ namespace DotNetCheck
 					RedirectOutput = Verbose
 				});
 
-				p.WaitForExit();
+				var sudoResult = p.WaitForExit();
+
+				// The authorization-dialog paths above throw on failure; this one used to
+				// discard the result, so a refused or failed sudo copy still reported the
+				// fix as applied. Fail the same way instead of silently doing nothing.
+				if (!sudoResult.Success)
+					throw new InvalidOperationException(
+						$"Elevated copy to '{destination}' failed with exit code {sudoResult.ExitCode}."
+						+ (Verbose ? $" Output:{Environment.NewLine}{sudoResult.GetOutput()}" : string.Empty));
 			}
 
 			return r;

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -57,6 +57,33 @@ namespace DotNetCheck
 		public static string LogFile { get; set; }
 		public static bool CI { get; set; }
 		public static bool NonInteractive { get; set; }
+		public static bool AllowElevationPrompt { get; set; }
+
+		/// <summary>
+		/// Structured hosts cannot provide a terminal for sudo. On macOS, use the system
+		/// administrator authorization dialog for the individual command instead.
+		/// CI remains strictly non-interactive.
+		/// </summary>
+		public static bool UseMacOsAdministratorPrompt
+			=> ShouldUseMacOsAdministratorPrompt(IsMac, CI, Json.JsonlOutput.Enabled, AllowElevationPrompt);
+
+		internal static bool ShouldUseMacOsAdministratorPrompt(bool isMac, bool ci, bool structuredOutput, bool allowElevationPrompt)
+			=> isMac && !ci && structuredOutput && allowElevationPrompt;
+
+		/// <summary>
+		/// Linux analog of <see cref="UseMacOsAdministratorPrompt"/>: the polkit dialog
+		/// (pkexec) authorizes the individual command on structured desktop hosts.
+		/// CI remains strictly non-interactive.
+		/// </summary>
+		public static bool UseLinuxAdministratorPrompt
+			=> ShouldUseLinuxAdministratorPrompt(IsLinux, CI, Json.JsonlOutput.Enabled, AllowElevationPrompt);
+
+		internal static bool ShouldUseLinuxAdministratorPrompt(bool isLinux, bool ci, bool structuredOutput, bool allowElevationPrompt)
+			=> isLinux && !ci && structuredOutput && allowElevationPrompt;
+
+		/// <summary>Any platform-native per-command authorization dialog is active.</summary>
+		public static bool UseAdministratorPrompt
+			=> UseMacOsAdministratorPrompt || UseLinuxAdministratorPrompt;
 
 		public static Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
 
@@ -209,7 +236,13 @@ namespace DotNetCheck
 
 		public static Task<ShellProcessRunner.ShellProcessResult> ShellCommand(string cmd, string workingDir, bool verbose, System.Threading.CancellationToken cancellationToken, string[] args)
 		{
-			var cli = new ShellProcessRunner(new ShellProcessRunnerOptions(cmd, string.Join(" ", args), cancellationToken) { WorkingDirectory = workingDir, Verbose = verbose } );
+			var cli = new ShellProcessRunner(new ShellProcessRunnerOptions(cmd, string.Empty, cancellationToken)
+			{
+				ArgumentList = args,
+				WorkingDirectory = workingDir,
+				Verbose = verbose,
+				UseSystemShell = false,
+			});
 			return Task.FromResult(cli.WaitForExit());
 		}
 
@@ -230,6 +263,26 @@ namespace DotNetCheck
 
 		public static Task<ShellProcessRunner.ShellProcessResult> WrapShellCommandWithSudo(string cmd, string workingDir, bool verbose, System.Threading.CancellationToken cancellationToken, bool noPrompt, string[] args)
 		{
+			if (!noPrompt && UseMacOsAdministratorPrompt)
+			{
+				return Task.FromResult(MacOsAdministratorCommandRunner.Run(
+					cmd,
+					workingDir,
+					verbose,
+					cancellationToken,
+					args));
+			}
+
+			if (!noPrompt && UseLinuxAdministratorPrompt)
+			{
+				return Task.FromResult(LinuxAdministratorCommandRunner.Run(
+					cmd,
+					workingDir,
+					verbose,
+					cancellationToken,
+					args));
+			}
+
 			var actualCmd = cmd;
 			var actualArgs = string.Join(" ", args);
 
@@ -242,11 +295,10 @@ namespace DotNetCheck
 				// shell once the outer `'...'` block is unwrapped. Without this, sudo retries on
 				// such installs fail with "command not found".
 				var quotedCmd = ShellDoubleQuote(cmd);
-				// Args are interpolated raw into the outer single-quoted block, so escape any
-				// embedded single quotes so they don't terminate the block early. Per-arg spaces
-				// are the caller's responsibility (e.g., BuildInstallArgs pre-wraps paths with
-				// inner double quotes).
-				var escapedArgs = actualArgs.Replace("'", "'\\''");
+				// Quote every argument before interpolation. These quotes become syntax for
+				// the command executed by the shell and prevent argument injection.
+				var quotedArgs = string.Join(" ", args.Select(MacOsAdministratorCommandRunner.PosixShellQuote));
+				var escapedArgs = quotedArgs.Replace("'", "'\\''");
 				actualArgs = $"-c '{sudoPrefix} {quotedCmd} {escapedArgs}'";
 			}
 
@@ -610,14 +662,50 @@ namespace DotNetCheck
 
 			if (r && !Util.IsWindows)
 			{
+				var quotedDestDir = MacOsAdministratorCommandRunner.PosixShellQuote(destDir);
+				var quotedIntermediate = MacOsAdministratorCommandRunner.PosixShellQuote(intermediate);
+				var quotedDestination = MacOsAdministratorCommandRunner.PosixShellQuote(destination);
+				var copyCommand = isFile
+					? $"mkdir -p {quotedDestDir} && cp -pP {quotedIntermediate} {quotedDestination}"
+					: $"mkdir -p {quotedDestDir} && cp -pPR {quotedIntermediate}/ {quotedDestination}";
+
+				if (UseMacOsAdministratorPrompt)
+				{
+					var elevatedResult = MacOsAdministratorCommandRunner.Run(
+						ShellProcessRunner.MacOSShell,
+						workingDirectory: null,
+						verbose: Verbose,
+						cancellationToken: System.Threading.CancellationToken.None,
+						arguments: new[] { "-c", copyCommand });
+
+					if (!elevatedResult.Success)
+						throw new InvalidOperationException(elevatedResult.GetOutput());
+
+					return true;
+				}
+
+				if (UseLinuxAdministratorPrompt)
+				{
+					// pkexec takes argv directly; the shell here only carries the && chain.
+					var elevatedResult = LinuxAdministratorCommandRunner.Run(
+						"/bin/sh",
+						workingDirectory: null,
+						verbose: Verbose,
+						cancellationToken: System.Threading.CancellationToken.None,
+						arguments: new[] { "-c", copyCommand });
+
+					if (!elevatedResult.Success)
+						throw new InvalidOperationException(elevatedResult.GetOutput());
+
+					return true;
+				}
+
 				// Copy a file to a destination as su
 				//		sudo mkdir -p destDir && sudo cp -pP intermediate destination
 
 				// Copy a folder recursively to the destination as su
 				//		sudo mkdir -p destDir && sudo cp -pPR intermediate/ destination
-				var args = isFile
-					? $"-c 'sudo mkdir -p \"{destDir}\" && sudo cp -pP \"{intermediate}\" \"{destination}\"'"
-					: $"-c 'sudo mkdir -p \"{destDir}\" && sudo cp -pPR \"{intermediate}/\" \"{destination}\"'"; // note the / at the end of the dir
+				var args = $"-c 'sudo {copyCommand.Replace("'", "'\\''")}'";
 
 				if (Verbose)
 					Console.WriteLine($"{ShellProcessRunner.MacOSShell} {args}");

--- a/UnoCheck/Util.cs
+++ b/UnoCheck/Util.cs
@@ -70,6 +70,21 @@ namespace DotNetCheck
 		internal static bool ShouldUseMacOsAdministratorPrompt(bool isMac, bool ci, bool structuredOutput, bool allowElevationPrompt)
 			=> isMac && !ci && structuredOutput && allowElevationPrompt;
 
+		/// <summary>
+		/// Linux analog of <see cref="UseMacOsAdministratorPrompt"/>: the polkit dialog
+		/// (pkexec) authorizes the individual command on structured desktop hosts.
+		/// CI remains strictly non-interactive.
+		/// </summary>
+		public static bool UseLinuxAdministratorPrompt
+			=> ShouldUseLinuxAdministratorPrompt(IsLinux, CI, Json.JsonlOutput.Enabled, AllowElevationPrompt);
+
+		internal static bool ShouldUseLinuxAdministratorPrompt(bool isLinux, bool ci, bool structuredOutput, bool allowElevationPrompt)
+			=> isLinux && !ci && structuredOutput && allowElevationPrompt;
+
+		/// <summary>Any platform-native per-command authorization dialog is active.</summary>
+		public static bool UseAdministratorPrompt
+			=> UseMacOsAdministratorPrompt || UseLinuxAdministratorPrompt;
+
 		public static Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
 
 		public static Platform Platform
@@ -251,6 +266,16 @@ namespace DotNetCheck
 			if (!noPrompt && UseMacOsAdministratorPrompt)
 			{
 				return Task.FromResult(MacOsAdministratorCommandRunner.Run(
+					cmd,
+					workingDir,
+					verbose,
+					cancellationToken,
+					args));
+			}
+
+			if (!noPrompt && UseLinuxAdministratorPrompt)
+			{
+				return Task.FromResult(LinuxAdministratorCommandRunner.Run(
 					cmd,
 					workingDir,
 					verbose,
@@ -648,6 +673,22 @@ namespace DotNetCheck
 				{
 					var elevatedResult = MacOsAdministratorCommandRunner.Run(
 						ShellProcessRunner.MacOSShell,
+						workingDirectory: null,
+						verbose: Verbose,
+						cancellationToken: System.Threading.CancellationToken.None,
+						arguments: new[] { "-c", copyCommand });
+
+					if (!elevatedResult.Success)
+						throw new InvalidOperationException(elevatedResult.GetOutput());
+
+					return true;
+				}
+
+				if (UseLinuxAdministratorPrompt)
+				{
+					// pkexec takes argv directly; the shell here only carries the && chain.
+					var elevatedResult = LinuxAdministratorCommandRunner.Run(
+						"/bin/sh",
 						workingDirectory: null,
 						verbose: Verbose,
 						cancellationToken: System.Threading.CancellationToken.None,

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -176,6 +176,10 @@ uno-check --fix --only androidsdk --non-interactive
 > [!NOTE]
 > An id that matches no checkup fails the run: the unknown ids are listed on stderr and the exit code is non-zero, so a typo can never produce a passing empty run.
 
+> [!NOTE]
+> With `--fix --non-interactive`, only the checkups named by `--only` are auto-fixed. Dependency checkups pulled into the run are examined for context but never fixed — a fix (and any elevation it needs) always corresponds to the checkup the caller requested. Interactive runs still confirm each fix individually.
+> Consequently, a host fixing several items in one child must name every selected id (`--only a --only b …`) instead of relying on a dependency to pull the rest in — which also keeps authorization prompts to exactly the items the user selected. A full-run `--fix` without `--only` still fixes everything it examines.
+
 ### `--json` Structured JSONL output
 
 Emits machine-readable JSONL on stdout — one JSON event per line (`run_started`, `checkup_started`, `checkup_progress`, `checkup_result`, `fix_started`, `fix_progress`, `fix_result`) ending with a final `report` event containing the full results and summary. The `report` event is emitted on every exit path — including cancellation and early failures — so consumers can treat it as the end-of-stream marker. Human-readable output moves to stderr so stdout stays pure JSONL. Implies `--non-interactive`.
@@ -204,11 +208,16 @@ Structured-output events carry a `correlation_id`, newly generated per run by de
 uno-check --fix --only androidsdk --json-file "%TEMP%\uno-check-fix-1234.jsonl" --correlation-id 6f2c1b6e
 ```
 
-### `--allow-elevation-prompt` Allow macOS administrator authorization
+### `--allow-elevation-prompt` Allow macOS / Linux authorization dialogs
 
-Allows a structured macOS fix run to display the system administrator authorization dialog when an individual solution needs to modify a protected location. Uno.Check itself remains in the current user's context; only the underlying command is authorized as an administrator. Declining the dialog produces a failed `fix_result` and the check remains unresolved.
+Allows a structured macOS or Linux fix run to display the system authorization dialog when an individual solution needs to modify a protected location. Uno.Check itself remains in the current user's context; only the underlying command is authorized:
 
-This option is opt-in because `--json` is also used by unattended consumers. It is ignored with `--ci`, and it does not change the existing interactive Terminal `sudo` flow.
+- **macOS** shows the system administrator authorization dialog.
+- **Linux** shows the polkit authentication dialog via `pkexec` (a polkit authentication agent must be running, as on any desktop session). If `pkexec` is not installed, the fix fails with a message naming the missing tool.
+
+Declining either dialog produces a failed `fix_result` (`Administrator approval was declined.`) and the check remains unresolved.
+
+This option is opt-in because `--json` is also used by unattended consumers. It is ignored with `--ci`, and it does not change the existing interactive terminal `sudo` flow.
 
 ```bash
 uno-check --fix --only xcode --json --allow-elevation-prompt

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -186,6 +186,8 @@ Emits machine-readable JSONL on stdout — one JSON event per line (`run_started
 
 Intended for host applications, CI pipelines, and AI agents that embed uno-check. The event schema is documented in the repository under `specs/003-structured-json-output`.
 
+A failing check that can be repaired carries a `fix` object: `auto_fixable` says the fix can be run, `args` is the argument vector to run it with, and `requires_elevation` says whether running it needs administrator/root rights — so a host only elevates the fixes that actually need it (installing workloads into a machine-wide SDK, enabling Hyper-V, the long-path registry key) and leaves user-scoped ones (templates, the Uno SDK restore, a user-local SDK, Android SDK packages) unelevated. It is conservative: anything not known to be user-scoped reports `true`.
+
 ```bash
 uno-check --json --target wasm > results.jsonl
 ```

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -178,6 +178,7 @@ uno-check --fix --only androidsdk --non-interactive
 
 > [!NOTE]
 > With `--fix --non-interactive`, only the checkups named by `--only` are auto-fixed. Dependency checkups pulled into the run are examined for context but never fixed — a fix (and any elevation it needs) always corresponds to the checkup the caller requested. Interactive runs still confirm each fix individually.
+> Consequently, a host fixing several items in one child must name every selected id (`--only a --only b …`) instead of relying on a dependency to pull the rest in — which also keeps authorization prompts to exactly the items the user selected. A full-run `--fix` without `--only` still fixes everything it examines.
 
 ### `--json` Structured JSONL output
 

--- a/doc/configuring-uno-check.md
+++ b/doc/configuring-uno-check.md
@@ -176,6 +176,10 @@ uno-check --fix --only androidsdk --non-interactive
 > [!NOTE]
 > An id that matches no checkup fails the run: the unknown ids are listed on stderr and the exit code is non-zero, so a typo can never produce a passing empty run.
 
+> [!NOTE]
+> With `--fix --non-interactive`, only the checkups named by `--only` are auto-fixed. Dependency checkups pulled into the run are examined for context but never fixed — a fix (and any elevation it needs) always corresponds to the checkup the caller requested. Interactive runs still confirm each fix individually.
+> Consequently, a host fixing several items in one child must name every selected id (`--only a --only b …`) instead of relying on a dependency to pull the rest in — which also keeps authorization prompts to exactly the items the user selected. A full-run `--fix` without `--only` still fixes everything it examines.
+
 ### `--json` Structured JSONL output
 
 Emits machine-readable JSONL on stdout — one JSON event per line (`run_started`, `checkup_started`, `checkup_progress`, `checkup_result`, `fix_started`, `fix_progress`, `fix_result`) ending with a final `report` event containing the full results and summary. The `report` event is emitted on every exit path — including cancellation and early failures — so consumers can treat it as the end-of-stream marker. Human-readable output moves to stderr so stdout stays pure JSONL. Implies `--non-interactive`.
@@ -202,6 +206,21 @@ Structured-output events carry a `correlation_id`, newly generated per run by de
 
 ```cmd
 uno-check --fix --only androidsdk --json-file "%TEMP%\uno-check-fix-1234.jsonl" --correlation-id 6f2c1b6e
+```
+
+### `--allow-elevation-prompt` Allow macOS / Linux authorization dialogs
+
+Allows a structured macOS or Linux fix run to display the system authorization dialog when an individual solution needs to modify a protected location. Uno.Check itself remains in the current user's context; only the underlying command is authorized:
+
+- **macOS** shows the system administrator authorization dialog.
+- **Linux** shows the polkit authentication dialog via `pkexec` (a polkit authentication agent must be running, as on any desktop session). If `pkexec` is not installed, the fix fails with a message naming the missing tool.
+
+Declining either dialog produces a failed `fix_result` (`Administrator approval was declined.`) and the check remains unresolved.
+
+This option is opt-in because `--json` is also used by unattended consumers. It is ignored with `--ci`, and it does not change the existing interactive terminal `sudo` flow.
+
+```bash
+uno-check --fix --only xcode --json --allow-elevation-prompt
 ```
 
 ### Exit codes

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -99,12 +99,32 @@ Stream guarantees:
 | `checkup_catalog` | emitted by `list --json` only: `schema_version`, `checkups[]` of `{ id, name, type_name }` (`name` is the display title, as in `checkup_result`; `type_name` is the checkup class name, which `--skip` also accepts) — the applicable-checkup menu for hosts building selection UIs that feed `--only`/`--skip` |
 
 **HealthCheck:** `id`, `name`, `status` (`ok`/`warning`/`error`/`skipped`), optional `message`,
-optional `skip_reason`, optional `fix` = `{ issue_id, description, auto_fixable, args }`.
+optional `skip_reason`, optional `fix` =
+`{ issue_id, description, auto_fixable, requires_elevation, args }`.
 `args` is the argument vector for the per-item fix (`["--fix", "--only", "<id>",
 "--non-interactive"]`), to be passed straight to the uno-check process — deliberately never a
 pre-joined command string, so no host is tempted to run it through a shell (checkup ids can
 embed manifest-sourced version text). Ids that fail the `[A-Za-z0-9._-]+` allowlist are never
 marked auto-fixable.
+
+`requires_elevation` answers *"will running `args` need administrator/root rights?"* — the
+question a host must settle **before** launching, because Windows elevates whole processes,
+not commands: without the signal the only safe choice is to elevate every fix, so
+user-scoped fixes (Android SDK packages, `dotnet new` templates, the Uno SDK restore,
+workloads into a user-writable SDK) raise UAC for nothing.
+
+- True when **any** solution behind the suggestion needs elevation — a fix applies them all,
+  so the host must satisfy the strictest one.
+- Conservative by construction: a solution requires elevation unless it is known to write
+  only user-scoped state. Layout-dependent solutions probe the real target instead of
+  assuming — the same workloads fix reports `false` against a user-local `DOTNET_ROOT` and
+  `true` against a Program Files SDK.
+- Advice-only suggestions (no runnable solution) report `false`; they also report
+  `auto_fixable: false`, so there is nothing to launch.
+- It describes the *fix*, not the current process: it stays meaningful when the host is
+  already elevated, and on macOS/Linux — where `--allow-elevation-prompt` elevates
+  per-command rather than per-process — it is what a host uses to warn that a dialog is
+  coming.
 
 **Report (final):** `schema_version`, `correlation_id`, `timestamp`, `tool_version`,
 `status` (`healthy`/`degraded`/`unhealthy`), optional `reason` (abnormal ends), `checks[]`,
@@ -138,10 +158,12 @@ checks failed.
    pins a released tool version, wrong for local dev builds.)
 2. Render per-check cards live from `checkup_*` events; summary from `report`.
 3. Fix one item:
-   - On Windows, launch elevated `uno-check --fix --only <id> --non-interactive
+   - On Windows, launch `uno-check --fix --only <id> --non-interactive
      --json-file <fresh-path> --correlation-id <this run's id>` using `fix.args` from the
-     check's result; tail the file for `fix_*` events and the fix child's own re-examined
-     `checkup_result`.
+     check's result, elevating the child (`runas`) **only when that check's
+     `fix.requires_elevation` is true**; tail the file for `fix_*` events and the fix
+     child's own re-examined `checkup_result`. The file transport is needed either way,
+     since an elevated child's stdout cannot be redirected.
    - On macOS, keep the same current-user JSON process and add `--allow-elevation-prompt`.
      User-level solutions run without a prompt. A solution that needs a protected location
      displays the system administrator dialog and elevates only its underlying command.
@@ -167,6 +189,9 @@ checks failed.
      Worth recording the observed value when next on a macOS host.
    - **A cached terminal `sudo` ticket is deliberately not reused**: authorization belongs to
      the fix the user clicked, so the dialog appears even right after a terminal `sudo`.
+   - **`fix.requires_elevation` is the pre-launch signal**, and it is what keeps user-scoped
+     fixes prompt-free: on Windows it decides `runas` before the child starts, and on
+     macOS/Linux a host can use it to warn that a dialog is coming.
 
 Host requirements:
 

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -150,15 +150,40 @@ checks failed.
      Declining the dialog — or a missing `pkexec` — surfaces as a failed `fix_result`.
    The terminal `report` marks the end of any child stream.
 
+   Authorization-dialog expectations for hosts:
+
+   - **Each protected command is its own authorization.** A single fix can prompt more than
+     once — e.g. a root-owned SDK's workloads fix runs repair and install through separate
+     elevated commands, so two dialogs. A "fix all" flow prompts the sum across items.
+     Solutions coalesce where they can (the apt-based fixes chain update+install into one
+     elevated shell), but hosts should not promise one dialog per fix.
+   - **The elevated command runs as root, not the user.** Per-user state the command touches
+     (NuGet caches, first-run sentinels) therefore lands by `HOME`: on Linux `pkexec` sets a
+     root `HOME` and scrubs the environment (the workload path re-injects what it needs via
+     `env`; on-host runs show root-owned artifacts under the system dotnet root). On macOS
+     the equivalent `HOME` under `do shell script … with administrator privileges` has not
+     been captured yet — either outcome is benign: root's home means a cold cache (slower),
+     the user's home means root-owned cache entries, same as the previous macOS `sudo` path.
+     Worth recording the observed value when next on a macOS host.
+   - **A cached terminal `sudo` ticket is deliberately not reused**: authorization belongs to
+     the fix the user clicked, so the dialog appears even right after a terminal `sudo`.
+
 Host requirements:
 
 - Drain stderr as well as stdout, or leave stderr unredirected: in `--json` mode the whole
   human-readable UI moves there, and an undrained pipe stalls the run once its buffer fills.
 - Treat process exit as an end-of-stream signal alongside `report`: an argument-parse failure
   produces no events and, on Windows, happens after the child's console has been hidden.
-- `fix.args` for an item scopes the run to that item **plus its required dependencies**, and
-  `--fix` applies to every checkup in the run — fixing the emulator can install the Android
-  SDK and JDK first. Surface that in the UI rather than promising a single-item change.
+- `fix.args` for an item scopes the run to that item **plus its required dependencies**, but
+  with `--only` present, `--fix --non-interactive` applies fixes **only to caller-named ids**
+  — dependencies are examined for context, never fixed. Two host-facing consequences:
+  - An item whose prerequisite is itself broken can resolve as `skipped` (dependency failure)
+    instead of fixed — the card goes from "Fix" to "skipped" with no visible progress unless
+    the host explains that the prerequisite must be fixed first.
+  - A "fix all" (or multi-item) flow must name **every** selected id (`--only a --only b …`)
+    rather than relying on dependency pull-in — which also keeps authorization prompts to
+    exactly the items the user selected. A full-run `--fix` without `--only` still fixes
+    everything it examines.
 
 ## Consumers
 

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -31,11 +31,14 @@ package:
    so the host tails the file instead.
 3. **`--only <checkup-id>`** — scope the run to the named checkup(s) plus their required
    dependencies (caller ids match exactly, case-insensitively; dependency ids keep the existing
-   one-way prefix rule). Repeatable.
-4. **`--allow-elevation-prompt`** — opt a structured macOS fix run into the system
-   administrator authorization dialog. Only the command requested by the active solution is
-   elevated; the Uno.Check process and its user-scoped path discovery remain unelevated. The
-   option is ignored in CI and does not affect the existing Terminal sudo flow.
+   one-way prefix rule). Repeatable. With `--fix --non-interactive`, only caller-named
+   checkups are auto-fixed: dependencies are examined for context but never fixed, so a
+   host-side elevation prompt always describes the fix the user requested.
+4. **`--allow-elevation-prompt`** — opt a structured macOS or Linux fix run into the system
+   authorization dialog (macOS administrator prompt; Linux polkit via `pkexec`). Only the
+   command requested by the active solution is elevated; the Uno.Check process and its
+   user-scoped path discovery remain unelevated. The option is ignored in CI and does not
+   affect the existing terminal sudo flow.
 
 ### Open question — execution level (deferred, needs maintainer sign-off)
 
@@ -142,7 +145,28 @@ checks failed.
    - On macOS, keep the same current-user JSON process and add `--allow-elevation-prompt`.
      User-level solutions run without a prompt. A solution that needs a protected location
      displays the system administrator dialog and elevates only its underlying command.
-   The terminal `report` marks the end of either child stream.
+   - On Linux, the same flag routes protected commands through the polkit dialog (`pkexec`),
+     which needs a running polkit authentication agent (present on any desktop session).
+     Declining the dialog — or a missing `pkexec` — surfaces as a failed `fix_result`.
+   The terminal `report` marks the end of any child stream.
+
+   Authorization-dialog expectations for hosts:
+
+   - **Each protected command is its own authorization.** A single fix can prompt more than
+     once — e.g. a root-owned SDK's workloads fix runs repair and install through separate
+     elevated commands, so two dialogs. A "fix all" flow prompts the sum across items.
+     Solutions coalesce where they can (the apt-based fixes chain update+install into one
+     elevated shell), but hosts should not promise one dialog per fix.
+   - **The elevated command runs as root, not the user.** Per-user state the command touches
+     (NuGet caches, first-run sentinels) therefore lands by `HOME`: on Linux `pkexec` sets a
+     root `HOME` and scrubs the environment (the workload path re-injects what it needs via
+     `env`; on-host runs show root-owned artifacts under the system dotnet root). On macOS
+     the equivalent `HOME` under `do shell script … with administrator privileges` has not
+     been captured yet — either outcome is benign: root's home means a cold cache (slower),
+     the user's home means root-owned cache entries, same as the previous macOS `sudo` path.
+     Worth recording the observed value when next on a macOS host.
+   - **A cached terminal `sudo` ticket is deliberately not reused**: authorization belongs to
+     the fix the user clicked, so the dialog appears even right after a terminal `sudo`.
 
 Host requirements:
 
@@ -150,9 +174,16 @@ Host requirements:
   human-readable UI moves there, and an undrained pipe stalls the run once its buffer fills.
 - Treat process exit as an end-of-stream signal alongside `report`: an argument-parse failure
   produces no events and, on Windows, happens after the child's console has been hidden.
-- `fix.args` for an item scopes the run to that item **plus its required dependencies**, and
-  `--fix` applies to every checkup in the run — fixing the emulator can install the Android
-  SDK and JDK first. Surface that in the UI rather than promising a single-item change.
+- `fix.args` for an item scopes the run to that item **plus its required dependencies**, but
+  with `--only` present, `--fix --non-interactive` applies fixes **only to caller-named ids**
+  — dependencies are examined for context, never fixed. Two host-facing consequences:
+  - An item whose prerequisite is itself broken can resolve as `skipped` (dependency failure)
+    instead of fixed — the card goes from "Fix" to "skipped" with no visible progress unless
+    the host explains that the prerequisite must be fixed first.
+  - A "fix all" (or multi-item) flow must name **every** selected id (`--only a --only b …`)
+    rather than relying on dependency pull-in — which also keeps authorization prompts to
+    exactly the items the user selected. A full-run `--fix` without `--only` still fixes
+    everything it examines.
 
 ## Consumers
 

--- a/specs/003-structured-json-output/spec.md
+++ b/specs/003-structured-json-output/spec.md
@@ -31,7 +31,14 @@ package:
    so the host tails the file instead.
 3. **`--only <checkup-id>`** — scope the run to the named checkup(s) plus their required
    dependencies (caller ids match exactly, case-insensitively; dependency ids keep the existing
-   one-way prefix rule). Repeatable.
+   one-way prefix rule). Repeatable. With `--fix --non-interactive`, only caller-named
+   checkups are auto-fixed: dependencies are examined for context but never fixed, so a
+   host-side elevation prompt always describes the fix the user requested.
+4. **`--allow-elevation-prompt`** — opt a structured macOS or Linux fix run into the system
+   authorization dialog (macOS administrator prompt; Linux polkit via `pkexec`). Only the
+   command requested by the active solution is elevated; the Uno.Check process and its
+   user-scoped path discovery remain unelevated. The option is ignored in CI and does not
+   affect the existing terminal sudo flow.
 
 ### Open question — execution level (deferred, needs maintainer sign-off)
 
@@ -130,10 +137,36 @@ checks failed.
    (`--ci` additionally enables strict manifest-version validation — appropriate when the host
    pins a released tool version, wrong for local dev builds.)
 2. Render per-check cards live from `checkup_*` events; summary from `report`.
-3. Fix one item: launch elevated `uno-check --fix --only <id> --non-interactive
-   --json-file <fresh-path> --correlation-id <this run's id>` using `fix.args` from the
-   check's result; tail the file for `fix_*` events and the fix child's own re-examined
-   `checkup_result`; the terminal `report` marks the end of the child's stream.
+3. Fix one item:
+   - On Windows, launch elevated `uno-check --fix --only <id> --non-interactive
+     --json-file <fresh-path> --correlation-id <this run's id>` using `fix.args` from the
+     check's result; tail the file for `fix_*` events and the fix child's own re-examined
+     `checkup_result`.
+   - On macOS, keep the same current-user JSON process and add `--allow-elevation-prompt`.
+     User-level solutions run without a prompt. A solution that needs a protected location
+     displays the system administrator dialog and elevates only its underlying command.
+   - On Linux, the same flag routes protected commands through the polkit dialog (`pkexec`),
+     which needs a running polkit authentication agent (present on any desktop session).
+     Declining the dialog — or a missing `pkexec` — surfaces as a failed `fix_result`.
+   The terminal `report` marks the end of any child stream.
+
+   Authorization-dialog expectations for hosts:
+
+   - **Each protected command is its own authorization.** A single fix can prompt more than
+     once — e.g. a root-owned SDK's workloads fix runs repair and install through separate
+     elevated commands, so two dialogs. A "fix all" flow prompts the sum across items.
+     Solutions coalesce where they can (the apt-based fixes chain update+install into one
+     elevated shell), but hosts should not promise one dialog per fix.
+   - **The elevated command runs as root, not the user.** Per-user state the command touches
+     (NuGet caches, first-run sentinels) therefore lands by `HOME`: on Linux `pkexec` sets a
+     root `HOME` and scrubs the environment (the workload path re-injects what it needs via
+     `env`; on-host runs show root-owned artifacts under the system dotnet root). On macOS
+     the equivalent `HOME` under `do shell script … with administrator privileges` has not
+     been captured yet — either outcome is benign: root's home means a cold cache (slower),
+     the user's home means root-owned cache entries, same as the previous macOS `sudo` path.
+     Worth recording the observed value when next on a macOS host.
+   - **A cached terminal `sudo` ticket is deliberately not reused**: authorization belongs to
+     the fix the user clicked, so the dialog appears even right after a terminal `sudo`.
 
 Host requirements:
 
@@ -141,9 +174,16 @@ Host requirements:
   human-readable UI moves there, and an undrained pipe stalls the run once its buffer fills.
 - Treat process exit as an end-of-stream signal alongside `report`: an argument-parse failure
   produces no events and, on Windows, happens after the child's console has been hidden.
-- `fix.args` for an item scopes the run to that item **plus its required dependencies**, and
-  `--fix` applies to every checkup in the run — fixing the emulator can install the Android
-  SDK and JDK first. Surface that in the UI rather than promising a single-item change.
+- `fix.args` for an item scopes the run to that item **plus its required dependencies**, but
+  with `--only` present, `--fix --non-interactive` applies fixes **only to caller-named ids**
+  — dependencies are examined for context, never fixed. Two host-facing consequences:
+  - An item whose prerequisite is itself broken can resolve as `skipped` (dependency failure)
+    instead of fixed — the card goes from "Fix" to "skipped" with no visible progress unless
+    the host explains that the prerequisite must be fixed first.
+  - A "fix all" (or multi-item) flow must name **every** selected id (`--only a --only b …`)
+    rather than relying on dependency pull-in — which also keeps authorization prompts to
+    exactly the items the user selected. A full-run `--fix` without `--only` still fixes
+    everything it examines.
 
 ## Consumers
 


### PR DESCRIPTION
Adds **`Uno.Check.Client`**: the reader half of the JSONL contract (spec 003). It builds uno-check's command lines and turns its output into typed events. It launches nothing and runs no checks.

Targets `dev/vs/json-output` (#551) because the contract test needs the writer that lands there.

## Why

Every consumer of the contract needs this code, and today each one writes it. The first host to adopt the contract hand-wrote ~500 lines of DTOs, event mapping and argument building that belong here — the next one would write them again.

Launch policy deliberately **stays with the host**: which version to pin, whether to invoke the installed global tool or `dnx`, and how to elevate are deployment decisions that differ per host. This package is only the parts that are the same everywhere.

## Drift is now a CI failure

The CLI can't reference the package — it still targets up to `net6.0` — so the writer and reader are mirrors rather than one definition. Mirrors drift: an earlier draft named the catalog title `title` while a consumer read `name`, and nothing caught it.

`ClientContractTests` renders **real writer events** and parses them with the **real client**, so a rename that compiles on one side fails here instead of in a host at runtime. Ten cases, covering elevation flags, skip reasons, failure reasons, and the catalog title specifically.

## Notes for review

- `netstandard2.0` keeps older hosts — and eventually the CLI itself — able to consume it; `net8.0` adds source-generated serialization for trimmed consumers.
- Publishing this package is what unblocks the consuming host; it currently carries its own copy and can't drop it until a version ships.
- Worth deciding as part of review: package versioning and whether it releases on the CLI's cadence or its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)